### PR TITLE
(MAINT) Update Slack URL to public channel

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -32,11 +32,11 @@ Activity-specific guidelines
 
 ### Getting technical help
 
-The Lumogon [Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5) and [Lumogon repository issues](https://github.com/puppetlabs/lumogon/issues) are the best places to seek out technical help.
+The Lumogon [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ) and [Lumogon repository issues](https://github.com/puppetlabs/lumogon/issues) are the best places to seek out technical help.
 
 ### Slack
 
-The [Lumogon Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5) on the [Puppet Community Slack](https://puppetcommunity.slack.com) is the official chat channel for the Lumogon project . The following guidelines apply to all Slack channels.
+The [Lumogon Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ) on the [Puppet Community Slack](https://puppetcommunity.slack.com) is the official chat channel for the Lumogon project . The following guidelines apply to all Slack channels.
 
 -   Don't be a jerk: Treat people with respect and consideration.
 -   Be helpful: Be patient with new people and be willing to jump in to answer questions.
@@ -54,7 +54,7 @@ Here are a few guidelines that apply specifically to filing issues:
 
 -   Each report is for only one issue. If you find several issues, please separate them into several reports.
 -   Search before you file an issue, and try to avoid filing duplicates by taking a look at whether your issue has already been filed before.
--   Don't start debates on topics not directly related to the scope of a specific issue. We have [other places](https://puppetcommunity.slack.com/messages/G58F97FC5) for general discussions.
+-   Don't start debates on topics not directly related to the scope of a specific issue. We have [other places](https://puppetcommunity.slack.com/messages/C5CT7GMKQ) for general discussions.
 -   Remove unnecessary lines when quoting other comments.
 -   Please double check to make sure that the information you are including is public (not confidential), especially in attached log files or screenshots.
 

--- a/README.md
+++ b/README.md
@@ -201,4 +201,4 @@ Note that this build process isn't widely tested away from macOS yet but will ev
 
 ## Giving us feedback
 
-We'd love to hear from you. We have a [Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5) for talking about Lumogon and please do open issues against [the repository](https://github.com/puppetlabs/lumogon/issues).
+We'd love to hear from you. We have a [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ) for talking about Lumogon and please do open issues against [the repository](https://github.com/puppetlabs/lumogon/issues).

--- a/examples/explore-lumogon-with-jq.md
+++ b/examples/explore-lumogon-with-jq.md
@@ -117,4 +117,4 @@ we want to set that information free so we can build tools to quickly answer
 questions and solve real user problems.
 
 If you're interested in these examples or have any questions about
-Lumogon then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5).
+Lumogon then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ).

--- a/examples/images-and-lumogon.md
+++ b/examples/images-and-lumogon.md
@@ -64,4 +64,4 @@ Lumogon and point the direction for the kinds of features we might add
 into the tool at a later stage.
 
 If you're interested in these examples or have any questions about Lumogon
-then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5).
+then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ).

--- a/examples/testing-with-lumogon.md
+++ b/examples/testing-with-lumogon.md
@@ -52,4 +52,4 @@ operating systems) were not present, or that all images where using the
 corporate standard operating system.
 
 If you're interested in these examples or have any questions about
-Lumogon then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/G58F97FC5).
+Lumogon then head over to our [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ).


### PR DESCRIPTION
This PR updates the various URLs for Slack to point to our now-public Slack support channel.