### PR TITLE
(MAINT) handle large stream frame payloads which are split across multiple Reads

### DIFF
--- a/capabilities/ospackages/apk.go
+++ b/capabilities/ospackages/apk.go
@@ -25,7 +25,7 @@ var apkCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"alpine": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Apk] Harvesting packages from %s [%s], harvestid: %s", id)
+		logging.Stderr("[Apk] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})

--- a/capabilities/ospackages/dpkg.go
+++ b/capabilities/ospackages/dpkg.go
@@ -25,7 +25,7 @@ var dpkgCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"ubuntu": 1, "debian": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Dpkg] Harvesting packages from %s [%s], harvestid: %s", id)
+		logging.Stderr("[Dpkg] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})

--- a/capabilities/ospackages/rpm.go
+++ b/capabilities/ospackages/rpm.go
@@ -25,7 +25,7 @@ var rpmCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"fedora": 1, "rhel": 1, "centos": 1, "opensuse": 1, "suse": 1, "ol": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Rpm] Harvesting packages from %s [%s], harvestid: %s", id)
+		logging.Stderr("[Rpm] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})

--- a/dockeradapter/filterdockerstream.go
+++ b/dockeradapter/filterdockerstream.go
@@ -39,7 +39,7 @@ type frameHeader struct {
 //
 // The following streamTypes are supported (from the Docker stdcopy package):
 //  - Stdin    - 0
-//  - Stderr   - 1
+//  - Stdout   - 1
 //  - Stderr   - 2
 //  - Systemerr - 3
 // The function works by walking the supplied stream alternating between reading

--- a/dockeradapter/filterdockerstream.go
+++ b/dockeradapter/filterdockerstream.go
@@ -14,7 +14,7 @@ const (
 	Stdin = iota
 	// Stdout represents standard output stream type.
 	Stdout
-	// Stderr represents standard error steam type.
+	// Stderr represents standard error stream type.
 	Stderr
 	// Systemerr represents errors originating from the system that make it
 	// into the the multiplexed stream.
@@ -24,7 +24,7 @@ const (
 	stdWriterSizeIndex = 4
 )
 
-// frameHeader holds the steam type and payload size for a Docker stream frame
+// frameHeader holds the stream type and payload size for a Docker stream frame
 type frameHeader struct {
 	streamType  int
 	payloadSize int
@@ -46,7 +46,7 @@ type frameHeader struct {
 // the prefix header bytes followed by the number of bytes specified in the prefix
 // size bytes.
 func FilterDockerStream(reader io.Reader, streamType int) ([]string, error) {
-	logging.Stderr("[FilterDockerstream] filtering reader for steam type: %d", streamType)
+	logging.Stderr("[FilterDockerstream] filtering reader for stream type: %d", streamType)
 	defer logging.Stderr("[FilterDockerstream] leaving")
 	result := []string{}
 	h, err := readFrameHeader(reader)

--- a/test/helper/timeoutreader.go
+++ b/test/helper/timeoutreader.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrTimeout is thrown when the number of valid reads is exceeded
+var ErrTimeout = errors.New("timeout")
+
+// TimeoutReader wraps a Reader and allows up to n valid reads after
+// which subsequent reads will return ErrTimeout
+func TimeoutReader(r io.Reader, n int) io.Reader { return &timeoutReader{r, 0, n} }
+
+type timeoutReader struct {
+	r          io.Reader
+	count      int
+	validReads int
+}
+
+func (r *timeoutReader) Read(p []byte) (int, error) {
+	r.count++
+	if r.count > r.validReads {
+		return 0, ErrTimeout
+	}
+	return r.r.Read(p)
+}


### PR DESCRIPTION
Prior to this PR the `FilterDockerStream` function wasn't handling large Docker stream frames where a single `Read` wasn't returning the whole buffer (as observed in #20).

This commit switches to using `io.LimitReader` with `ioutil.ReadAll` to read the entire frame payload.

It refactors `FilterDockerStream` adding local functions for reading the frame headers and payloads.

It also includes some minor log message tweaks in the `apk`, `dpkg` and `rpm` capabilities.