### PR TITLE
[FEAT] [WIP] Run Lumogon on ARM (Raspberry Pi)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ endif
 
 PACKAGE_NAME = github.com/puppetlabs/lumogon
 
+DOCKER_IMAGE_NAME ?= puppet/lumogon
+
 LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildTime=$(shell date -u '+%Y-%m-%d %I:%M:%S %Z')"
 LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildVersion=development"
 LDFLAGS += -X "$(PACKAGE_NAME)/version.BuildSHA=$(shell git rev-parse HEAD)"
@@ -27,7 +29,7 @@ dependencies: bootstrap
 	glide install
 
 test: lint vet
-	go test -v -cover `glide novendor` -ldflags '$(TESTLDFLAGS)'
+	GOOS= GOARCH= go test -v -cover `glide novendor` -ldflags '$(TESTLDFLAGS)'
 
 watch: bootstrap
 	goconvey
@@ -37,7 +39,7 @@ build: bootstrap
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -a -ldflags '$(LDFLAGS)' -o bin/lumogon lumogon.go
 
 image: bootstrap
-	docker build -t puppet/lumogon -f ./Dockerfile.build .
+	docker build -t $(DOCKER_IMAGE_NAME) -f ./Dockerfile.build .
 
 todo:
 	grep -rnw "TODO" .
@@ -46,7 +48,7 @@ lint: bootstrap $(GOPATH)/src/github.com/golang/lint/golint
 	golint `glide novendor`
 
 vet: bootstrap
-	go vet `glide novendor`
+	GOOS= GOARCH= go vet `glide novendor`
 
 licenses: $(GOPATH)/bin/licenses
 	@licenses  $(PACKAGE_NAME) | grep $(PACKAGE_NAME)/vendor

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ make all
 
 Note that this build process isn't widely tested away from macOS yet but will eventually work everywhere.
 
+### Building for ARM (Raspberry Pi)
+
+You can build a Lumogon container that will run on ARM based platforms (tested on the Raspberry Pi) as follows:
+```
+GOARCH=arm GOOS=linux DOCKER_IMAGE_NAME=yourname/lumogon-arm make all
+```
+
 ## Giving us feedback
 
 We'd love to hear from you. We have a [Slack channel](https://puppetcommunity.slack.com/messages/C5CT7GMKQ) for talking about Lumogon and please do open issues against [the repository](https://github.com/puppetlabs/lumogon/issues).

--- a/capabilities/ospackages/dpkg.go
+++ b/capabilities/ospackages/dpkg.go
@@ -22,7 +22,7 @@ var dpkgCapability = dockeradapter.DockerAPICapability{
 		Description: dpkgDescription,
 		Type:        "dockerapi",
 		Payload:     nil,
-		SupportedOS: map[string]int{"ubuntu": 1, "debian": 1},
+		SupportedOS: map[string]int{"ubuntu": 1, "debian": 1, "raspbian": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
 		logging.Stderr("[Dpkg] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)

--- a/dockeradapter/image.go
+++ b/dockeradapter/image.go
@@ -1,0 +1,29 @@
+package dockeradapter
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/puppetlabs/lumogon/logging"
+	"github.com/puppetlabs/lumogon/utils"
+)
+
+// LocalImageID returns the imageID sha256 hex for the local container
+func LocalImageID(ctx context.Context, client Inspector) (*string, error) {
+	localContainerID, err := utils.GetLocalContainerID("/proc/self/cgroup")
+	if err != nil {
+		logging.Stderr("[LocalImageID] unable to determine local ContainerID: %v", err)
+		return nil, err
+	}
+	var imageIDRegex = regexp.MustCompile(`^sha256:([a-z0-9]+)`)
+
+	json, err := client.ContainerInspect(ctx, localContainerID)
+	if err != nil {
+		logging.Stderr("[LocalImageID] error inspecting local container [ID: %s]: %v", localContainerID)
+		return nil, err
+	}
+
+	imageID := imageIDRegex.FindStringSubmatch(json.Image)[1]
+	logging.Stderr("[LocalImageID] found local imageID: %s", imageID)
+	return &imageID, nil
+}


### PR DESCRIPTION
![raspberrypi-sensehat](https://cloud.githubusercontent.com/assets/83862/26332307/c0811d76-3f4d-11e7-86e5-fe8f3e993bfc.gif)

Raising this for visibility/feedback. I've tested this locally on a Raspberry Pi running Docker and have made an image available `johnmccabe/lumogon-arm`.

```
pi@pi3:~$ uname -a
Linux pi3 4.9.24-v7+ #993 SMP Wed Apr 26 18:01:23 BST 2017 armv7l GNU/Linux

pi@pi3:~$ cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 8 (jessie)"
NAME="Raspbian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"

pi@pi3:~$ docker ps
CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                     NAMES
0a9331d9056e        alexellis2/nginx-arm        "/usr/sbin/nginx -..."   11 hours ago        Up About an hour    80/tcp                    reverent_meitner
3e7090d7bd2a        hypriot/rpi-dockerui        "/dockerui"              11 hours ago        Up About an hour    0.0.0.0:32768->9000/tcp   silly_swartz
235216495ff5        hypriot/rpi-busybox-httpd   "/bin/busybox http..."   12 hours ago        Up About an hour    0.0.0.0:32769->80/tcp     elated_panini

pi@pi3:~$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock johnmccabe/lumogon-arm report
Unable to find image 'johnmccabe/lumogon-arm:latest' locally
latest: Pulling from johnmccabe/lumogon-arm
404291400c57: Pull complete
b0f21d3b4f7e: Pull complete
Digest: sha256:c7cd19b41ade16c6750482d62cc690d4afa109518fc9cfb8d3502abef25590ba
Status: Downloaded newer image for johnmccabe/lumogon-arm:latest

https://reporter.app.lumogon.com/xgAgDoPn76HAAqzeKZyBv08cXrsgJMSx1ZeQGLLRFT4=
```

- [ ] Test on Scaleway
- [ ] Test on Beaglebone Black
