### PR TITLE
(MAINT) Repair Analytics Reporting Regression

### DIFF
--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -60,7 +60,7 @@ func NewUserSession() *UserSession {
 
 // ScreenView is the public function to post a ScreenView analytics message to GA
 func ScreenView(screen string) {
-	logging.Stderr("[Analytics] Gathering analytics for screen-view, %s", screen)
+	logging.Stderr("[Analytics] Initializing Google Analytics for screen: %s", screen)
 	u := *NewUserSession()
 	u.Type = "screenview"
 	u.ScreenName = screen
@@ -69,7 +69,7 @@ func ScreenView(screen string) {
 
 // Event is the public function to post a ScreenView event analytics message to GA
 func Event(action string, category string) {
-	logging.Stderr("[Analytics] Gathering analytics for event, %s", category)
+	logging.Stderr("[Analytics] Gathering additional Google Analytics for event: %s", category)
 	u := *NewUserSession()
 	u.Type = "event"
 	u.Action = action

--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -60,7 +60,7 @@ func NewUserSession() *UserSession {
 
 // ScreenView is the public function to post a ScreenView analytics message to GA
 func ScreenView(screen string) {
-	logging.Stderr("[Analytics] Initializing Google Analytics for screen: %s", screen)
+	logging.Stderr("[Analytics] Initializing Google Analytics: %s", screen)
 	u := *NewUserSession()
 	u.Type = "screenview"
 	u.ScreenName = screen

--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -60,6 +60,7 @@ func NewUserSession() *UserSession {
 
 // ScreenView is the public function to post a ScreenView analytics message to GA
 func ScreenView(screen string) {
+	logging.Stderr("[Analytics] Gathering analytics for screen-view, %s", screen)
 	u := *NewUserSession()
 	u.Type = "screenview"
 	u.ScreenName = screen
@@ -68,7 +69,7 @@ func ScreenView(screen string) {
 
 // Event is the public function to post a ScreenView event analytics message to GA
 func Event(action string, category string) {
-	logging.Stderr("[Analytics] Creating analytics event, %s", category)
+	logging.Stderr("[Analytics] Gathering analytics for event, %s", category)
 	u := *NewUserSession()
 	u.Type = "event"
 	u.Action = action

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,5 +27,5 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().BoolVarP(&logging.Debug, "debug", "d", false, "Print debug logging")
 	RootCmd.PersistentFlags().Bool("disable-analytics", false, "Disable sending anonymous data for product improvement")
-	viper.BindPFlag("port", RootCmd.PersistentFlags().Lookup("disable-analytics"))
+	viper.BindPFlag("disable-analytics", RootCmd.PersistentFlags().Lookup("disable-analytics"))
 }


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/puppetlabs/lumogon/commit/d128444ce0da6c5540a2cf78b6a14b15bd35439b where the correct Viper bind is not used for the `disable-analytics` endpoint. As a result, this has been ignored and all reports have been sending analytics data upstream regardless of flag being set.

