### PR TITLE
[FEAT] Add container filesystem size capability

### DIFF
--- a/capabilities/filesystem/filesystem.go
+++ b/capabilities/filesystem/filesystem.go
@@ -1,0 +1,55 @@
+package filesystem
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/puppetlabs/lumogon/capabilities/payloadfilter"
+	"github.com/puppetlabs/lumogon/capabilities/registry"
+	"github.com/puppetlabs/lumogon/dockeradapter"
+	"github.com/puppetlabs/lumogon/logging"
+	"github.com/puppetlabs/lumogon/types"
+)
+
+var filesystemDescription = `The filesystem capability returns sizes of filesystem in a container as a map["layer"]"size"`
+
+// The filesystemCapability capability output from the container runtime inspect
+var filesystemCapability = dockeradapter.DockerAPICapability{
+	Capability: types.Capability{
+		Schema:      "http://puppet.com/lumogon/capability/diff/draft-01/schema#1",
+		Title:       "Filesystem",
+		Name:        "filesystem",
+		Description: filesystemDescription,
+		Type:        "dockerapi",
+		Payload:     nil,
+		SupportedOS: map[string]int{"all": 1},
+	},
+	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
+		logging.Stderr("[Filesystem] Harvesting filesystem sizes from %s [%s]", target.Name, target.ID)
+		capability.HarvestID = id
+		logging.Stderr("[Filesystem] Harvesting filesystem capability, harvestid: %s", capability.HarvestID)
+
+		ctx := context.Background()
+		output := make(map[string]interface{})
+
+		containerData, err := client.ContainerFilesystem(ctx, target.ID)
+		if err != nil {
+			errorMsg := fmt.Sprintf("[Filesystem] Error getting filesystem data from targetContainer: %s, error: %s", target.Name, err)
+			logging.Stderr(errorMsg)
+			capability.PayloadError(errorMsg)
+			return
+		}
+
+		output["sizerw"] = containerData.SizeRw
+		output["sizerootfs"] = containerData.SizeRootFs
+		filtered, _ := payloadfilter.Filter(output)
+		logging.Stderr("[Filesystem]   Output: %v", output)
+		logging.Stderr("[Filesystem]   Filtered: %v", filtered)
+		capability.Payload = filtered
+	},
+}
+
+func init() {
+	logging.Stderr("[Filesystem] Initialising capability: %s", filesystemCapability.Title)
+	registry.Registry.Add(filesystemCapability)
+}

--- a/capabilities/filesystem/init.go
+++ b/capabilities/filesystem/init.go
@@ -1,0 +1,7 @@
+package filesystem
+
+// Init exists to allow host init() functions to run when
+// invoked from the capabilities Init function, which is
+// itself invoked by the Lumogon command handler.
+func Init() {
+}

--- a/capabilities/init.go
+++ b/capabilities/init.go
@@ -1,6 +1,7 @@
 package capabilities
 
 import (
+	"github.com/puppetlabs/lumogon/capabilities/filesystem"
 	"github.com/puppetlabs/lumogon/capabilities/host"
 	"github.com/puppetlabs/lumogon/capabilities/label"
 	"github.com/puppetlabs/lumogon/capabilities/ospackages"
@@ -9,7 +10,9 @@ import (
 // Init exists to allow capabilities init() functions to run when
 // invoked from the Lumogon command handler.
 func Init() {
+
 	host.Init()
 	label.Init()
 	ospackages.Init()
+	filesystem.Init()
 }

--- a/test/mocks/dockerclient.go
+++ b/test/mocks/dockerclient.go
@@ -7,6 +7,7 @@ import (
 
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/puppetlabs/lumogon/types"
 	"github.com/puppetlabs/lumogon/utils"
 )
 
@@ -30,6 +31,7 @@ type MockDockerClient struct {
 	ContainerExecInspectFn func(ctx context.Context, execID string) (dockertypes.ContainerExecInspect, error)
 	ImageInspectFn         func(ctx context.Context, imageName string) (dockertypes.ImageInspect, error)
 	CopyFromContainerFn    func(ctx context.Context, container, srcPath string, followSymlink bool) (io.ReadCloser, dockertypes.ContainerPathStat, error)
+	ContainerFilesystemFn  func(ctx context.Context, containerID string) (types.Filesystem, error)
 }
 
 // ImagePull is a mock implementation of dockeradapter.ImagePull
@@ -193,6 +195,15 @@ func (c MockDockerClient) CopyFromContainer(ctx context.Context, container, srcP
 	if c.CopyFromContainerFn != nil {
 		fmt.Println("[MockDockerClient] In ", utils.CurrentFunctionName())
 		return c.CopyFromContainerFn(ctx, container, srcPath, followSymlink)
+	}
+	panic(fmt.Sprintf("No function defined for: %s", utils.CurrentFunctionName()))
+}
+
+// ContainerFilesystem is a mock implementation of dockeradapter.ContainerFilesystem
+func (c MockDockerClient) ContainerFilesystem(ctx context.Context, containerID string) (types.Filesystem, error) {
+	if c.ContainerFilesystemFn != nil {
+		fmt.Println("[MockDockerClient] In ", utils.CurrentFunctionName())
+		return c.ContainerFilesystemFn(ctx, containerID)
 	}
 	panic(fmt.Sprintf("No function defined for: %s", utils.CurrentFunctionName()))
 }

--- a/types/filesystem.go
+++ b/types/filesystem.go
@@ -1,0 +1,7 @@
+package types
+
+// Filesystem captures size information for a container's filesystem and root filesystem
+type Filesystem struct {
+	SizeRw     int64 `json:"sizerw"`
+	SizeRootFs int64 `json:"sizerootfs"`
+}


### PR DESCRIPTION
![](https://cdn-ds.com/media/2108/w_1920/newFUC_PC_2dd4x104VER2.png)

This is currently only close to working (or so I think). It adds a new "filesystem" capability, uses `ContainerList` with a container `id` filter to retrieve information about our specific container, and then extracts the `SizeRW` and `SizeRootFs` data.


**todo**

 - [x] build basic capability
 - [x] track down how to get info on a specific container
 - [x] extract FS sizes
 - [ ] fix a bug(?) -- FS sizes always appear to be 0

---

The only downside is that these two values are always 0 so far. I'm seeing `docker ps` with the `-s` flag returning size information:

```
CONTAINER ID                                                       IMAGE                                                          COMMAND                                                                                              CREATED             STATUS              PORTS                    NAMES                                                            SIZE
9b2e43a432b1884823fbc08e37cabf13ea143de2fd80af57e245ccbb0f0a4662   dockercomposefortesting_jenkins                                "/usr/bin/dumb-init -- mvn hpi:run"                                                                  About an hour ago   Created                                      dockercomposefortesting_jenkins_1                                0 B (virtual 1.56 GB)
9d7cb1822ae0a37a22442bc42111cb4290068bb5904136432192a2bc2d4aa32a   dockercomposefortesting_always-be-scheduling-queue-processor   "/bin/sh -c 'bundle exec queue-processor'"                                                           About an hour ago   Up About an hour                             dockercomposefortesting_always-be-scheduling-queue-processor_1   1.67 MB (virtual 350 MB)
41635ddc76a574026a2888c11ac016539b84caa9da86010f899106abd0746225   dockercomposefortesting_always-be-scheduling                   "/bin/sh -c 'bundle exec rackup config.ru'"                                                          About an hour ago   Up About an hour    0.0.0.0:9292->9292/tcp   dockercomposefortesting_always-be-scheduling_1                   1.67 MB (virtual 350 MB)
6fd42069baa1d364f862900390ac5f147a833cfc142c00519f32ecd550322d69   dockercomposefortesting_redis                                  "/usr/bin/dumb-init -- /usr/bin/redis-server /etc/redis/redis.conf"                                  About an hour ago   Up About an hour    0.0.0.0:6379->6379/tcp   dockercomposefortesting_redis_1                                  1.84 kB (virtual 178 MB)
6c2ef95354ffb977356c109c2d86881af7e38f57fec73806a327502120c9c962   peopleperhour/dynamodb                                         "/usr/bin/java -Djava.library.path=. -jar DynamoDBLocal.jar -dbPath /var/dynamodb_local -sharedDb"   11 days ago         Up 11 days          0.0.0.0:8000->8000/tcp   dynamodb                                                         32.8 kB (virtual 331 MB)
```

The information begin returned by the capability has the two size entries set to 0:

```
lumogon scan --debug 2>&1 | grep -i sizerw
[lumogon] 2017/05/30 21:35:22.912838 [Filesystem] ([]types.Container)[{ID:(string)6c2ef95354ffb977356c109c2d86881af7e38f57fec73806a327502120c9c962 Names:([]string)[/dynamodb] Image:(string)peopleperhour/dynamodb ImageID:(string)sha256:e181bb615ecd45b568be3eb057089b0fac538e696d4cba66f253428a1a532825 Command:(string)/usr/bin/java -Djava.library.path=. -jar DynamoDBLocal.jar -dbPath /var/dynamodb_local -sharedDb Created:(int64)1495225277 Ports:([]types.Port)[{IP:(string)0.0.0.0 PrivatePort:(uint16)8000 PublicPort:(uint16)8000 Type:(string)tcp}] SizeRw:(int64)0 SizeRootFs:(int64)0 Labels:(map[string]string)map[] State:(string)running Status:(string)Up 11 days HostConfig:(struct { NetworkMode string "json:\",omitempty\"" }){NetworkMode:(string)default} NetworkSettings:(*types.SummaryNetworkSettings)(0xc4202e42c8){Networks:(map[string]*network.EndpointSettings)map[bridge:<*>(0xc4202f89c0){IPAMConfig:(*network.EndpointIPAMConfig)<nil> Links:([]string)<nil> Aliases:([]string)<nil> NetworkID:(string)e42f575f257f3f4324faa1c04bed0c76070280eb1d310dca179fa8b734e3c915 EndpointID:(string)a0cabb90c3b67d128ba51ae34cef6d0e87066cde51b5158e5023dcf5452c7bc0 Gateway:(string)172.17.0.1 IPAddress:(string)172.17.0.2 IPPrefixLen:(int)16 IPv6Gateway:(string) GlobalIPv6Address:(string) GlobalIPv6PrefixLen:(int)0 MacAddress:(string)02:42:ac:11:00:02}]} Mounts:([]types.MountPoint)[{Type:(mount.Type)volume Name:(string)c05b94b4e988d634f005fe92884eb656d5c757e7ddd11d0b5d17f8bf889bdd56 Source:(string)/var/lib/docker/volumes/c05b94b4e988d634f005fe92884eb656d5c757e7ddd11d0b5d17f8bf889bdd56/_data Destination:(string)/var/dynamodb_wd Driver:(string)local Mode:(string) RW:(bool)true Propagation:(mount.Propagation)} {Type:(mount.Type)volume Name:(string)3ab60ba696f5330609d5f4721fb9f4124615b6441d82af61d42c67c2310f2e60 Source:(string)/var/lib/docker/volumes/3ab60ba696f5330609d5f4721fb9f4124615b6441d82af61d42c67c2310f2e60/_data Destination:(string)/var/dynamodb_local Driver:(string)local Mode:(string) RW:(bool)true Propagation:(mount.Propagation)}]}]
[lumogon] 2017/05/30 21:35:22.912885 [Filesystem]   Output: map[sizerw:0 sizerootfs:0]
[lumogon] 2017/05/30 21:35:22.913180 [Filesystem] ([]types.Container)[{ID:(string)6fd42069baa1d364f862900390ac5f147a833cfc142c00519f32ecd550322d69 Names:([]string)[/dockercomposefortesting_redis_1] Image:(string)dockercomposefortesting_redis ImageID:(string)sha256:55558e8fe39a0990f6e6f10293ab9cc3311781cc249c87990107602ee7013fa8 Command:(string)/usr/bin/dumb-init -- /usr/bin/redis-server /etc/redis/redis.conf Created:(int64)1496176536 Ports:([]types.Port)[{IP:(string)0.0.0.0 PrivatePort:(uint16)6379 PublicPort:(uint16)6379 Type:(string)tcp}] SizeRw:(int64)0 SizeRootFs:(int64)0 Labels:(map[string]string)map[com.docker.compose.config-hash:206705373d5d1aec9cf00ae0825218792863c9fb35851ae50f7f2dbdc2154c1a com.docker.compose.container-number:1 com.docker.compose.oneoff:False com.docker.compose.project:dockercomposefortesting com.docker.compose.service:redis com.docker.compose.version:1.11.2] State:(string)running Status:(string)Up 59 minutes HostConfig:(struct { NetworkMode string "json:\",omitempty\"" }){NetworkMode:(string)dockercomposefortesting_default} NetworkSettings:(*types.SummaryNetworkSettings)(0xc42000ce50){Networks:(map[string]*network.EndpointSettings)map[dockercomposefortesting_default:<*>(0xc4200c8b40){IPAMConfig:(*network.EndpointIPAMConfig)<nil> Links:([]string)<nil> Aliases:([]string)<nil> NetworkID:(string)d703c2a7bbddb8d78b4cdced842602bcb4a1a13c5b65509857e641b04f94701d EndpointID:(string)9dcbfaf82852ec0e1f13f060c7fbaf618b08e8c5953a9b8c3278a87478f10d24 Gateway:(string)172.18.0.1 IPAddress:(string)172.18.0.2 IPPrefixLen:(int)16 IPv6Gateway:(string) GlobalIPv6Address:(string) GlobalIPv6PrefixLen:(int)0 MacAddress:(string)02:42:ac:12:00:02}]} Mounts:([]types.MountPoint)[{Type:(mount.Type)volume Name:(string)2b93bd8e7154a10efea302fa3614f36393e500c2ee163825177dce25cb9bbc1d Source:(string)/var/lib/docker/volumes/2b93bd8e7154a10efea302fa3614f36393e500c2ee163825177dce25cb9bbc1d/_data Destination:(string)/data Driver:(string)local Mode:(string) RW:(bool)true Propagation:(mount.Propagation)}]}]
[lumogon] 2017/05/30 21:35:22.913195 [Filesystem]   Output: map[sizerw:0 sizerootfs:0]
[lumogon] 2017/05/30 21:35:22.914109 [Filesystem] ([]types.Container)[{ID:(string)9d7cb1822ae0a37a22442bc42111cb4290068bb5904136432192a2bc2d4aa32a Names:([]string)[/dockercomposefortesting_always-be-scheduling-queue-processor_1] Image:(string)dockercomposefortesting_always-be-scheduling-queue-processor ImageID:(string)sha256:575e13cee8a33788c41317f4a787fe20d2922ad84f58a361836f0238d3e2e7f1 Command:(string)/bin/sh -c 'bundle exec queue-processor' Created:(int64)1496176537 Ports:([]types.Port)[] SizeRw:(int64)0 SizeRootFs:(int64)0 Labels:(map[string]string)map[name:CentOS Base Image com.docker.compose.config-hash:3e578edd3d82fa8c2471f8f48b51072beb02f76fafccd6b054c5b35f0f2e463d com.docker.compose.service:always-be-scheduling-queue-processor license:GPLv2 com.docker.compose.project:dockercomposefortesting com.docker.compose.version:1.11.2 vendor:CentOS build-date:20160729 com.docker.compose.container-number:1 com.docker.compose.oneoff:False] State:(string)running Status:(string)Up 59 minutes HostConfig:(struct { NetworkMode string "json:\",omitempty\"" }){NetworkMode:(string)dockercomposefortesting_default} NetworkSettings:(*types.SummaryNetworkSettings)(0xc42000cee8){Networks:(map[string]*network.EndpointSettings)map[dockercomposefortesting_default:<*>(0xc4200c8cc0){IPAMConfig:(*network.EndpointIPAMConfig)<nil> Links:([]string)<nil> Aliases:([]string)<nil> NetworkID:(string)d703c2a7bbddb8d78b4cdced842602bcb4a1a13c5b65509857e641b04f94701d EndpointID:(string)11b846f33214fa81e2280f14a86900520b298f6923a28509a29f5b39699aaf2b Gateway:(string)172.18.0.1 IPAddress:(string)172.18.0.4 IPPrefixLen:(int)16 IPv6Gateway:(string) GlobalIPv6Address:(string) GlobalIPv6PrefixLen:(int)0 MacAddress:(string)02:42:ac:12:00:04}]} Mounts:([]types.MountPoint)[]}]
[lumogon] 2017/05/30 21:35:22.914132 [Filesystem]   Output: map[sizerw:0 sizerootfs:0]
[lumogon] 2017/05/30 21:35:22.915309 [Filesystem] ([]types.Container)[{ID:(string)41635ddc76a574026a2888c11ac016539b84caa9da86010f899106abd0746225 Names:([]string)[/dockercomposefortesting_always-be-scheduling_1] Image:(string)dockercomposefortesting_always-be-scheduling ImageID:(string)sha256:3128fb35b1911596bb41ba892976578c5f9761d73f8c6fd58a46d4bff575dfdc Command:(string)/bin/sh -c 'bundle exec rackup config.ru' Created:(int64)1496176537 Ports:([]types.Port)[{IP:(string)0.0.0.0 PrivatePort:(uint16)9292 PublicPort:(uint16)9292 Type:(string)tcp}] SizeRw:(int64)0 SizeRootFs:(int64)0 Labels:(map[string]string)map[license:GPLv2 name:CentOS Base Image com.docker.compose.service:always-be-scheduling com.docker.compose.version:1.11.2 vendor:CentOS build-date:20160729 com.docker.compose.config-hash:6ca05b82d3c33b452a22a786658bb2772f5ed7b22d39bbe454c21d2a5e14f24c com.docker.compose.container-number:1 com.docker.compose.oneoff:False com.docker.compose.project:dockercomposefortesting] State:(string)running Status:(string)Up 59 minutes HostConfig:(struct { NetworkMode string "json:\",omitempty\"" }){NetworkMode:(string)dockercomposefortesting_default} NetworkSettings:(*types.SummaryNetworkSettings)(0xc4202e42e0){Networks:(map[string]*network.EndpointSettings)map[dockercomposefortesting_default:<*>(0xc4202f8a80){IPAMConfig:(*network.EndpointIPAMConfig)<nil> Links:([]string)<nil> Aliases:([]string)<nil> NetworkID:(string)d703c2a7bbddb8d78b4cdced842602bcb4a1a13c5b65509857e641b04f94701d EndpointID:(string)62e08ea0edbc4c46291f9f5c252ac25eeb3d25a49557c822fd376a2ca588fd5c Gateway:(string)172.18.0.1 IPAddress:(string)172.18.0.3 IPPrefixLen:(int)16 IPv6Gateway:(string) GlobalIPv6Address:(string) GlobalIPv6PrefixLen:(int)0 MacAddress:(string)02:42:ac:12:00:03}]} Mounts:([]types.MountPoint)[]}]
[lumogon] 2017/05/30 21:35:22.915370 [Filesystem]   Output: map[sizerw:0 sizerootfs:0]
```

cc @puppetlabs/lumogon 