### PR TITLE
(TC-156) Add HTTP timeout catch and error handling for report

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"time"
@@ -104,17 +103,10 @@ func storeResult(report types.Report, consumerURL string) error {
 	resp, err := http.Post(consumerURL, "application/json", bytes.NewBuffer(jsonStr))
 
 	if err != nil {
-		switch err := err.(type) {
-		case net.Error:
-			if err.Timeout() {
-				os.Stderr.WriteString(fmt.Sprintf("Unable to connect to the HTTP endpoint at %s\nSending scan report to fallback: STDOUT\n", consumerURL))
-				outputResult(report)
-				os.Exit(1)
-			}
-		default:
-			logging.Stderr("[Storage] Error posting result, [%s], exiting.", err)
-			os.Exit(1)
-		}
+		logging.Stderr("[Storage] Error posting result, [%s], exiting.", err)
+		os.Stderr.WriteString(fmt.Sprintf("Unable to connect to the HTTP endpoint at %s\nSending scan report to fallback: STDOUT\n", consumerURL))
+		outputResult(report)
+		os.Exit(1)
 	}
 
 	analytics.Event("upload", "UX")


### PR DESCRIPTION
This PR updates the `report` handling endpoint to respond gracefully in the event of a HTTP timeout so the user knows what is going on.

Example: https://gist.github.com/jfryman/a29faaa8bedb4fb5da10698e238db4ea

