### PR TITLE
(MAINT) Use Docker build stages to compose image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - DOCKER_IMAGE=puppet/lumogon
   - DOCKER_USER=jfryman
   - secure: Q5+WSF1b7tBzaVKWIIAOT4ItlcSj38eVMw5XAWkpw4XRaO1lu1awuvsx2XBDlZaLdcvm6S45HbM/6wX4/ZoBcv0rVx5Bd4ojranXEby4aIwPAxWx4hJ2plIgoQGWcRH576Nh7WumpW+kBllpYI8pcziW6bAA59SsX9OESBsmTK4+dSR8efBWUYQzTccsU0X+x+5HEot2wb/4j6/Xpis1zsMSEWL33j/KLSp3e4CE4DjoFONr3UiSII3RAmHjus/4C47S7bx1JGv3sZgQ96pVt0zZO4Au1Nn+R85caAJqm31Vx7mEDENYnLbfAKuGXWoRzV+1odFDsk5UUwRGEgc+w9+r0nrFfCn22NgCk5R5smmNr7yXbpt3ECLfuEglTkeD6qpyOckf5rgY0y834iQURYhEJPnh6v8f2C1XntDYsgyb0ni9Um6D2CYM4hp7yWw0aW+59Ia5cs/E5JgYIqsHuiAyoVuVcmnMXHhGwD+G8YhGCpahe1u0aNRGifdYmatzBXR8iGUh/RbEpXdIXQmpvgR2bFcfnuKIbV/WIVjejzxiFJmjSBYKs93J5BBJww7W8v2+e+WuDs5uiLpYtQFMeqaAua4NwxyQlyEKgAYTCQfy1DsjkKhWiTmlJ2b05LHE30RRKHYVbJRoW51xsTvE43wzmtAQ63vg5PUvwh6xnKs=
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
 matrix:
   include:
   - go: 1.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.8.3 as builder
+RUN mkdir -p /go/src/github.com/puppetlabs/lumogon/
+COPY . /go/src/github.com/puppetlabs/lumogon/
+WORKDIR /go/src/github.com/puppetlabs/lumogon/
+RUN make build
+
+FROM scratch
+ENV LUMOGON_ENDPOINT=https://consumer.app.lumogon.com/api/v1/
+COPY --from=builder /go/src/github.com/puppetlabs/lumogon/bin/lumogon /
+COPY --from=builder /go/src/github.com/puppetlabs/lumogon/certs/ca-certificates.crt /etc/ssl/certs/
+ENTRYPOINT ["/lumogon"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-FROM scratch
-
-ENV LUMOGON_ENDPOINT=https://consumer.app.lumogon.com/api/v1/
-
-COPY ./bin/lumogon /
-COPY ./certs/ca-certificates.crt /etc/ssl/certs/
-ENTRYPOINT ["/lumogon"]

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ bin/lumogon:
 
 build: bin/lumogon bootstrap
 
-image: build
-	docker build -t $(CONTAINER_NAME) -f ./Dockerfile.build .
+image:
+	docker build -t $(CONTAINER_NAME) .
 
 deploy: image
 	script/deploy
@@ -60,8 +60,6 @@ licenses: $(GOPATH)/bin/licenses
 
 all: clean dependencies test build image
 
-buildimage: clean build image
-
 $(GOPATH)/bin/glide:
 	go get -u github.com/Masterminds/glide
 
@@ -76,4 +74,4 @@ $(GOPATH)/bin/goconvey:
 
 bootstrap: $(GOPATH)/bin/glide $(GOPATH)/src/github.com/golang/lint/golint $(GOPATH)/bin/licenses $(GOPATH)/bin/goconvey
 
-.PHONY: build image buildimage test todo clean dependencies bootstrap licenses watch deploy
+.PHONY: build image test todo clean dependencies bootstrap licenses watch deploy

--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ Feel free to explore those command-line options. Of note:
 If you're making changes to Lumogon, or just interested in seeing how it works under the hood, you might want to try building from source. For this you'll need a few more things:
 
  - Install [Go](https://golang.org/dl/), version 1.8 or later
- - Install `make`
- - Set your `$GOPATH` variable to the path where you want to keep your Go sources -- for example, `${HOME}/go`.
+ - Docker [Docker](https://www.docker.com/get-docker), version 17.05 or later
  - Download the Lumogon source code
  - Build the Docker image
 
@@ -203,14 +202,12 @@ The terminal commands to do this are:
 
 ```shell
 export GOPATH="${HOME}/go"
-mkdir -p ${GOPATH}/src/github.com/puppetlabs
-cd ${GOPATH}/src/github.com/puppetlabs
-git clone https://github.com/puppetlabs/lumogon
+go get -d -u github.com/puppetlabs/lumogon
 cd $GOPATH/src/github.com/puppetlabs/lumogon
-make all
+make image
 ```
 
-Note that this build process isn't widely tested away from macOS yet but will eventually work everywhere.
+This will build the client and package it in the `puppet/lumogon` image.
 
 ## Giving us feedback
 


### PR DESCRIPTION
This PR uses the build stages feature to build the client and subsequent image from the same Dockerfile.

It requires the use of the current edge release `17.05`.