### PR TITLE
(TC-157) Output message when scanning each container

### DIFF
--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -60,7 +60,7 @@ func NewUserSession() *UserSession {
 
 // ScreenView is the public function to post a ScreenView analytics message to GA
 func ScreenView(screen string) {
-	logging.Stderr("[Analytics] Initializing Google Analytics: %s", screen)
+	logging.Debug("[Analytics] Initializing Google Analytics: %s", screen)
 	u := *NewUserSession()
 	u.Type = "screenview"
 	u.ScreenName = screen
@@ -69,7 +69,7 @@ func ScreenView(screen string) {
 
 // Event is the public function to post a ScreenView event analytics message to GA
 func Event(action string, category string) {
-	logging.Stderr("[Analytics] Gathering additional Google Analytics for event: %s", category)
+	logging.Debug("[Analytics] Gathering additional Google Analytics for event: %s", category)
 	u := *NewUserSession()
 	u.Type = "event"
 	u.Action = action
@@ -93,10 +93,10 @@ func (u UserSession) PostMeasurement() (*http.Response, error) {
 	}
 
 	if u.DisableTransmit == true {
-		logging.Stderr("[Analytics] Skipping submission of Google Analytics event")
+		logging.Debug("[Analytics] Skipping submission of Google Analytics event")
 		return nil, nil
 	}
 
-	logging.Stderr("[Analytics] Submitting event to Google Analytics")
+	logging.Debug("[Analytics] Submitting event to Google Analytics")
 	return u.HTTPClient.Do(req)
 }

--- a/capabilities/host/host.go
+++ b/capabilities/host/host.go
@@ -36,7 +36,7 @@ var hostCapability = types.AttachedCapability{
 		SupportedOS: map[string]int{"all": 1},
 	},
 	Harvest: func(capability *types.AttachedCapability, id string, args []string) {
-		logging.Stderr("[Host] Harvesting host capability, capability harvest id: %s", id)
+		logging.Debug("[Host] Harvesting host capability, capability harvest id: %s", id)
 
 		capability.HarvestID = id
 		h, _ := gopsutilhost.Info()
@@ -64,6 +64,6 @@ func InfostatToMap(h *gopsutilhost.InfoStat) map[string]interface{} {
 }
 
 func init() {
-	logging.Stderr("[Host] Initialising capability: %s", hostCapability.Title)
+	logging.Debug("[Host] Initialising capability: %s", hostCapability.Title)
 	registry.Registry.Add(hostCapability)
 }

--- a/capabilities/label/label.go
+++ b/capabilities/label/label.go
@@ -33,9 +33,9 @@ var labelCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"all": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Label] Harvesting label from %s [%s]", target.Name, target.ID)
+		logging.Debug("[Label] Harvesting label from %s [%s]", target.Name, target.ID)
 		capability.HarvestID = id
-		logging.Stderr("[Label]Harvesting label capability, harvestid: %s", capability.HarvestID)
+		logging.Debug("[Label]Harvesting label capability, harvestid: %s", capability.HarvestID)
 
 		ctx := context.Background()
 		output := make(map[string]interface{})
@@ -43,7 +43,7 @@ var labelCapability = dockeradapter.DockerAPICapability{
 		containerJSON, err := client.ContainerInspect(ctx, target.ID)
 		if err != nil {
 			errorMsg := fmt.Sprintf("[Label] Error inspecting targetContainer: %s, error: %s", target.Name, err)
-			logging.Stderr(errorMsg)
+			logging.Debug(errorMsg)
 			capability.PayloadError(errorMsg)
 			return
 		}
@@ -58,6 +58,6 @@ var labelCapability = dockeradapter.DockerAPICapability{
 }
 
 func init() {
-	logging.Stderr("[Label] Initialising capability: %s", labelCapability.Title)
+	logging.Debug("[Label] Initialising capability: %s", labelCapability.Title)
 	registry.Registry.Add(labelCapability)
 }

--- a/capabilities/ospackages/apk.go
+++ b/capabilities/ospackages/apk.go
@@ -25,7 +25,7 @@ var apkCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"alpine": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Apk] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
+		logging.Debug("[Apk] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})
@@ -46,6 +46,6 @@ var apkCapability = dockeradapter.DockerAPICapability{
 }
 
 func init() {
-	logging.Stderr("[Apk] Initialising capability: %s", apkCapability.Title)
+	logging.Debug("[Apk] Initialising capability: %s", apkCapability.Title)
 	registry.Registry.Add(apkCapability)
 }

--- a/capabilities/ospackages/dpkg.go
+++ b/capabilities/ospackages/dpkg.go
@@ -25,7 +25,7 @@ var dpkgCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"ubuntu": 1, "debian": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Dpkg] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
+		logging.Debug("[Dpkg] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})
@@ -45,6 +45,6 @@ var dpkgCapability = dockeradapter.DockerAPICapability{
 }
 
 func init() {
-	logging.Stderr("[Dpkg] Initialising capability: %s", dpkgCapability.Title)
+	logging.Debug("[Dpkg] Initialising capability: %s", dpkgCapability.Title)
 	registry.Registry.Add(dpkgCapability)
 }

--- a/capabilities/ospackages/package.go
+++ b/capabilities/ospackages/package.go
@@ -17,41 +17,41 @@ func runPackageCmd(client dockeradapter.Harvester, containerID string, cmd []str
 	execInstance, err := client.ContainerExecCreate(ctx, containerID, cmd, attachStdout, attachStderr)
 	if err != nil {
 		err = fmt.Errorf("[Package] Unable to create exec: %s", err)
-		logging.Stderr(err.Error())
+		logging.Debug(err.Error())
 		return nil, err
 	}
-	logging.Stderr("[Package] Container Exec Created, ID: %s", execInstance.ID)
+	logging.Debug("[Package] Container Exec Created, ID: %s", execInstance.ID)
 
 	att, err := client.ContainerExecAttach(ctx, execInstance.ID, cmd, attachStdout, attachStderr)
 	if err != nil {
 		err = fmt.Errorf("[Package] Unable to attach exec: %s", err)
-		logging.Stderr(err.Error())
+		logging.Debug(err.Error())
 		return nil, err
 	}
-	logging.Stderr("[Package] Container Exec Attached, ID: %s", execInstance.ID)
+	logging.Debug("[Package] Container Exec Attached, ID: %s", execInstance.ID)
 
 	defer att.Close()
 
-	logging.Stderr("[Package] About to do exec start for package capability")
+	logging.Debug("[Package] About to do exec start for package capability")
 	err = client.ContainerExecStart(ctx, execInstance.ID)
 	if err != nil {
 		err = fmt.Errorf("[Package] Error starting exec: %s", err)
-		logging.Stderr(err.Error())
+		logging.Debug(err.Error())
 		return nil, err
 	}
 
 	execInfo, err := client.ContainerExecInspect(ctx, execInstance.ID)
 	if err != nil {
 		err = fmt.Errorf("[Package] Error inspecting exec: %s", err)
-		logging.Stderr(err.Error())
+		logging.Debug(err.Error())
 		return nil, err
 	}
 
 	if execInfo.ExitCode != 0 {
-		logging.Stderr("[Package] package query returned a non-zero exit code: %d", execInfo.ExitCode)
+		logging.Debug("[Package] package query returned a non-zero exit code: %d", execInfo.ExitCode)
 		return nil, err
 	}
-	logging.Stderr("[Package] package query returned exit code: %d", execInfo.ExitCode)
+	logging.Debug("[Package] package query returned exit code: %d", execInfo.ExitCode)
 
 	execStdout, err := dockeradapter.FilterDockerStream(att.Reader, 1)
 	if err != nil {
@@ -60,7 +60,7 @@ func runPackageCmd(client dockeradapter.Harvester, containerID string, cmd []str
 
 	packages, err := utils.CsvToMap(execStdout)
 	if err != nil {
-		logging.Stderr("[Package] Error converting package csv to map")
+		logging.Debug("[Package] Error converting package csv to map")
 		return nil, err
 	}
 

--- a/capabilities/ospackages/rpm.go
+++ b/capabilities/ospackages/rpm.go
@@ -25,7 +25,7 @@ var rpmCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"fedora": 1, "rhel": 1, "centos": 1, "opensuse": 1, "suse": 1, "ol": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Stderr("[Rpm] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
+		logging.Debug("[Rpm] Harvesting packages from target %s [%s], harvester id: %s", target.Name, target.ID, id)
 		capability.HarvestID = id
 
 		output := make(map[string]interface{})
@@ -45,6 +45,6 @@ var rpmCapability = dockeradapter.DockerAPICapability{
 }
 
 func init() {
-	logging.Stderr("[Rpm] Initialising capability: %s", rpmCapability.Title)
+	logging.Debug("[Rpm] Initialising capability: %s", rpmCapability.Title)
 	registry.Registry.Add(rpmCapability)
 }

--- a/capabilities/registry/registry.go
+++ b/capabilities/registry/registry.go
@@ -35,13 +35,13 @@ var Registry CapabilitiesRegistry
 func (c CapabilitiesRegistry) Add(capability interface{}) {
 	switch capability.(type) {
 	case types.AttachedCapability:
-		logging.Stderr("[Registry] Adding ATTACHED capability to registry: %s\n", capability.(types.AttachedCapability).Title)
+		logging.Debug("[Registry] Adding ATTACHED capability to registry: %s\n", capability.(types.AttachedCapability).Title)
 		Registry.attached = append(Registry.attached, capability.(types.AttachedCapability))
 	case dockeradapter.DockerAPICapability:
-		logging.Stderr("[Registry] Adding DOCKER API capability to registry: %s\n", capability.(dockeradapter.DockerAPICapability).Title)
+		logging.Debug("[Registry] Adding DOCKER API capability to registry: %s\n", capability.(dockeradapter.DockerAPICapability).Title)
 		Registry.dockerAPI = append(Registry.dockerAPI, capability.(dockeradapter.DockerAPICapability))
 	default:
-		logging.Stdout("[Registry] Invalid capability type detected. Exiting..")
+		logging.Info("[Registry] Invalid capability type detected. Exiting..")
 		os.Exit(1)
 	}
 }
@@ -95,9 +95,9 @@ func Harvest(client dockeradapter.Harvester, targetContainerID string) map[strin
 
 	if client == nil {
 		// Runs on the attached Harvester
-		logging.Stderr("[Registry] Harvesting %d attached capabilities", len(Registry.AttachedCapabilities()))
+		logging.Debug("[Registry] Harvesting %d attached capabilities", len(Registry.AttachedCapabilities()))
 		for _, attachedcapability := range Registry.AttachedCapabilities() {
-			logging.Stderr("- %s\n", attachedcapability.Name)
+			logging.Debug("- %s\n", attachedcapability.Name)
 			attachedcapability.Harvest(&attachedcapability, utils.GenerateUUID4(), []string{})
 			harvestedData[attachedcapability.Name] = attachedcapability.Capability
 		}
@@ -111,7 +111,7 @@ func stringToTargetContainer(ctx context.Context, containerIDOrName string, clie
 	containerJSON, err := client.ContainerInspect(ctx, containerIDOrName)
 	if err != nil {
 		error := fmt.Sprintf("[Registry] Unable to find target container: %s, error: %s", containerIDOrName, err)
-		logging.Stderr(error)
+		logging.Debug(error)
 	}
 	targetContainer := types.TargetContainer{
 		ID:   containerJSON.ContainerJSONBase.ID,

--- a/cmd/harvest.go
+++ b/cmd/harvest.go
@@ -27,14 +27,14 @@ var harvestCmd = &cobra.Command{
 			ID:   args[0],
 			Name: args[1],
 		}
-		logging.Stderr("Harvesting from container: %s [%s]", target.Name, target.ID)
+		logging.Debug("Harvesting from container: %s [%s]", target.Name, target.ID)
 
 		containerReport := harvester.GenerateContainerReport(target, registry.Harvest(nil, target.ID))
 		harvesterHostname, _ := os.Hostname()
 		containerReport.HarvesterContainerID = harvesterHostname
 		_, err := rpcreceiver.SendResult(*containerReport, harvesterHostname)
 		if err != nil {
-			logging.Stderr("Error Submitting result to remote server: %s", err)
+			logging.Debug("Error Submitting result to remote server: %s", err)
 			os.Exit(1)
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,13 +19,13 @@ var RootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		logging.Stderr("Error initialising command: %s", err)
+		logging.Debug("Error initialising command: %s", err)
 		os.Exit(-1)
 	}
 }
 
 func init() {
-	RootCmd.PersistentFlags().BoolVarP(&logging.Debug, "debug", "d", false, "Print debug logging")
+	RootCmd.PersistentFlags().BoolVarP(&logging.DebugEnabled, "debug", "d", false, "Print debug logging")
 	RootCmd.PersistentFlags().Bool("disable-analytics", false, "Disable sending anonymous data for product improvement")
 	viper.BindPFlag("disable-analytics", RootCmd.PersistentFlags().Lookup("disable-analytics"))
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -34,7 +34,7 @@ func printVersion() {
 	// Dump the rendered version template to stdout
 	renderedVersionOutput, err := renderVersionTemplate()
 	if err != nil {
-		logging.Stderr("Unable to render version template [%s]", err)
+		logging.Debug("Unable to render version template [%s]", err)
 	}
 	fmt.Println(renderedVersionOutput)
 }

--- a/dockeradapter/dockeradapter.go
+++ b/dockeradapter/dockeradapter.go
@@ -122,7 +122,7 @@ func ImageExists(ctx context.Context, client ImageInspector, imageName string) b
 // New returns a client satisfying the Client interface
 func New() (Client, error) {
 	concreteClient := new(concreteDockerClient)
-	logging.Stderr("[Docker Adapter] Creating container runtime client: Docker")
+	logging.Debug("[Docker Adapter] Creating container runtime client: Docker")
 	dockerAPIClient, err := client.NewEnvClient()
 	if err != nil {
 		return nil, fmt.Errorf("[Docker Adapter] Unable to initialise container runtime type: Docker, error: %s", err)
@@ -245,7 +245,7 @@ func (c *concreteDockerClient) ContainerLogs(ctx context.Context, containerID st
 func (c *concreteDockerClient) CopyFromContainer(ctx context.Context, container, srcPath string, followSymlink bool) (io.ReadCloser, dockertypes.ContainerPathStat, error) {
 	readCloser, containerPathStat, err := c.Client.CopyFromContainer(ctx, container, srcPath)
 	if followSymlink && err == nil && containerPathStat.LinkTarget != "" {
-		logging.Stderr("[Docker Adapter] Resolving symlink for: %s, to: %s", srcPath, containerPathStat.LinkTarget)
+		logging.Debug("[Docker Adapter] Resolving symlink for: %s, to: %s", srcPath, containerPathStat.LinkTarget)
 		readCloser, containerPathStat, err = c.Client.CopyFromContainer(ctx, container, containerPathStat.LinkTarget)
 	}
 	return readCloser, containerPathStat, err
@@ -258,7 +258,7 @@ func (c *concreteDockerClient) ContainerList(ctx context.Context) ([]string, err
 
 	containers, err := c.Client.ContainerList(ctx, containerListOptions)
 	if err != nil {
-		logging.Stderr("[Docker Adapter] Error listing running containers: %s", err)
+		logging.Debug("[Docker Adapter] Error listing running containers: %s", err)
 		return nil, err
 	}
 

--- a/harvester/attached.go
+++ b/harvester/attached.go
@@ -21,12 +21,13 @@ import (
 // attached container which performed the harvest before sending the result to the
 // collector via the main results channel, resultsCh.
 func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*types.TargetContainer, capabilities []types.AttachedCapability, resultsCh chan types.ContainerReport, opts types.ClientOptions, client dockeradapter.Client) error {
-	defer logging.Stderr("[Attached Harvester] Exiting")
+	defer logging.Debug("[Attached Harvester] Exiting")
 	defer wg.Done()
-	logging.Stderr("[Attached Harvester] Running")
+	logging.Debug("[Attached Harvester] Running")
 
 	validTargets := []*types.TargetContainer{}
 	for _, target := range targets {
+		logging.Info("Scanning: " + target.Name)
 		for _, capability := range capabilities {
 			if _, ok := capability.SupportedOS["all"]; ok {
 				validTargets = append(validTargets, target)
@@ -43,18 +44,18 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 		errorMsg := fmt.Errorf("[Attached Harvester] No targets found with supported capabilities")
 		return errorMsg
 	}
-	logging.Stderr("[Attached Harvester] Running")
+	logging.Debug("[Attached Harvester] Running")
 	if len(capabilities) == 0 {
-		logging.Stderr("[Attached Harvester] No Attached Capabilities found")
+		logging.Debug("[Attached Harvester] No Attached Capabilities found")
 		return nil
 	}
 
 	rpcReceiverResultsCh := make(chan types.ContainerReport)
 
-	logging.Stderr("[Attached Harvester] Starting RPC Receiver")
+	logging.Debug("[Attached Harvester] Starting RPC Receiver")
 	go rpcreceiver.Run("attachedharvester", 42586, rpcReceiverResultsCh) // TODO Port is still hardcoded client side (probably not an issue?)
 
-	logging.Stderr("[Attached Harvester] Creating [%d] harvesting containers", len(validTargets))
+	logging.Debug("[Attached Harvester] Creating [%d] harvesting containers", len(validTargets))
 	for _, target := range validTargets {
 		go createAndRunHarvester(ctx, client, *target, opts, rpcReceiverResultsCh)
 	}
@@ -63,8 +64,8 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 	go func() {
 		for i := 1; i <= len(validTargets); i++ {
 			result := <-rpcReceiverResultsCh
-			logging.Stderr("[Attached Harvester] RPC result received from name: %s, ID: %s", result.ContainerName, result.ContainerID)
-			logging.Stderr("[Attached Harvester] Sending to collector via resultsCh")
+			logging.Debug("[Attached Harvester] RPC result received from name: %s, ID: %s", result.ContainerName, result.ContainerID)
+			logging.Debug("[Attached Harvester] Sending to collector via resultsCh")
 			resultsCh <- result
 		}
 		doneChannel <- 0
@@ -73,9 +74,9 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 	var err error
 	select {
 	case <-doneChannel:
-		logging.Stderr("[Attached Harvester] All expected results received")
+		logging.Debug("[Attached Harvester] All expected results received")
 	case <-ctx.Done():
-		logging.Stderr("[Attached Harvester] Context timed out waiting for results, continuing...")
+		logging.Debug("[Attached Harvester] Context timed out waiting for results, continuing...")
 		err = ctx.Err()
 	}
 
@@ -86,7 +87,7 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 // container which will run the harvest command to run the harvest functions from any registered
 // AttachedCapabilities.
 func createAndRunHarvester(ctx context.Context, client dockeradapter.Client, target types.TargetContainer, opts types.ClientOptions, rpcReceiverResultsCh chan types.ContainerReport) {
-	logging.Stderr("[Attached Harvester] Creating attached container for target %s", target)
+	logging.Debug("[Attached Harvester] Creating attached container for target %s", target)
 	harvester := NewAttachedContainer(client, types.ClientOptions{KeepHarvesters: opts.KeepHarvesters})
 	// TODO get image name from the current container or set alternate default for non-container use
 	harvester.GetImage("puppet/lumogon")

--- a/harvester/attachedcontainer.go
+++ b/harvester/attachedcontainer.go
@@ -69,7 +69,7 @@ func (a *AttachedContainer) Attach(target types.TargetContainer) {
 // present on the system
 func (a *AttachedContainer) GetImage(imageName string) {
 	if !dockeradapter.ImageExists(a.ctx, a.client, imageName) {
-		logging.Stderr("[AttachedContainer] Pulling image: %s", imageName)
+		logging.Debug("[AttachedContainer] Pulling image: %s", imageName)
 		err := a.client.ImagePull(a.ctx, imageName)
 		if err != nil {
 			a.err = err
@@ -85,7 +85,7 @@ func (a *AttachedContainer) Run() {
 		return
 	}
 
-	logging.Stderr("[AttachedContainer] Starting harvester ID: %s, attached to: %s [%s]", a.id, a.target.ID, a.target.Name)
+	logging.Debug("[AttachedContainer] Starting harvester ID: %s, attached to: %s [%s]", a.id, a.target.ID, a.target.Name)
 	err := a.client.ContainerStart(a.ctx, a.id)
 	if err != nil {
 		a.err = err
@@ -94,8 +94,8 @@ func (a *AttachedContainer) Run() {
 
 // createContainer creates the AttachedContainer attaching it to the target container
 func (a *AttachedContainer) createContainer() {
-	logging.Stderr("[AttachedContainer] Creating container: %s", a.name)
-	logging.Stderr("[AttachedContainer] Attaching container to ID: %s, Name: %s", a.target.ID, a.target.Name)
+	logging.Debug("[AttachedContainer] Creating container: %s", a.name)
+	logging.Debug("[AttachedContainer] Attaching container to ID: %s, Name: %s", a.target.ID, a.target.Name)
 
 	command := []string{"harvest", a.target.ID, a.target.Name, "-d"}
 	// Envvars used by gopsutil to query attached container
@@ -114,7 +114,7 @@ func (a *AttachedContainer) createContainer() {
 
 	container, err := a.client.ContainerCreate(a.ctx, command, envvars, a.imageName, binds, links, kernelCapabilities, pidMode, a.name, !a.keepHarvester)
 	if err != nil {
-		logging.Stderr("[AttachedContainer] Error creating container: %s", err)
+		logging.Debug("[AttachedContainer] Error creating container: %s", err)
 		a.err = err
 		return
 	}

--- a/harvester/dockerapi.go
+++ b/harvester/dockerapi.go
@@ -16,12 +16,12 @@ import (
 // Harvest function from each capabilitie before sending the result to the collector via the
 // main results channel, resultsCh.
 func RunDockerAPIHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*types.TargetContainer, capabilities []dockeradapter.DockerAPICapability, resultsCh chan types.ContainerReport, client dockeradapter.Harvester) error {
-	defer logging.Stderr("[DockerAPI Harvester] Exiting")
+	defer logging.Debug("[DockerAPI Harvester] Exiting")
 	defer wg.Done()
 
-	logging.Stderr("[DockerAPI Harvester] Running")
+	logging.Debug("[DockerAPI Harvester] Running")
 	if len(capabilities) == 0 {
-		logging.Stderr("[DockerAPI Harvester] No Docker API Capabilities found")
+		logging.Debug("[DockerAPI Harvester] No Docker API Capabilities found")
 		return nil
 	}
 
@@ -33,8 +33,8 @@ func RunDockerAPIHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*t
 
 	for i := range targets {
 		result := <-dockerAPIResultsCh
-		logging.Stderr("[DockerAPI Harvester] Result [%d] received from name: %s, ID: %s", i, result.ContainerName, result.ContainerID)
-		logging.Stderr("[DockerAPI Harvester] Sending to collector via resultsCh")
+		logging.Debug("[DockerAPI Harvester] Result [%d] received from name: %s, ID: %s", i, result.ContainerName, result.ContainerID)
+		logging.Debug("[DockerAPI Harvester] Sending to collector via resultsCh")
 		resultsCh <- *result
 	}
 
@@ -44,15 +44,15 @@ func RunDockerAPIHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*t
 func harvestDockerAPICapabilities(target types.TargetContainer, client dockeradapter.Harvester, capabilities []dockeradapter.DockerAPICapability, dockerAPIResultsCh chan *types.ContainerReport) {
 	harvestedData := map[string]types.Capability{}
 
-	logging.Stderr("[DockerAPI Harvester] Harvesting %d dockerAPI capabilities", len(capabilities))
+	logging.Debug("[DockerAPI Harvester] Harvesting %d dockerAPI capabilities", len(capabilities))
 	for _, capability := range capabilities {
 		if !utils.KeyInMap("all", capability.SupportedOS) && !utils.KeyInMap(target.OSID, capability.SupportedOS) {
-			logging.Stderr("[DockerAPI Harvester] skipping capability: %s, incompatible target OS: %s", capability.Name, target.OSID)
+			logging.Debug("[DockerAPI Harvester] skipping capability: %s, incompatible target OS: %s", capability.Name, target.OSID)
 			continue
 		}
-		logging.Stderr("[DockerAPI Harvester] Harvesting %s\n", capability.Name)
+		logging.Debug("[DockerAPI Harvester] Harvesting %s\n", capability.Name)
 		capability.Harvest(&capability, client, utils.GenerateUUID4(), target)
-		logging.Stderr("[DockerAPI Harvester] Storing result %s\n", capability.Name)
+		logging.Debug("[DockerAPI Harvester] Storing result %s\n", capability.Name)
 		harvestedData[capability.Name] = capability.Capability
 	}
 

--- a/harvester/rpcreceiver/client.go
+++ b/harvester/rpcreceiver/client.go
@@ -22,7 +22,7 @@ func SendResult(result types.ContainerReport, harvesterHostname string) (bool, e
 	var ack bool
 	err = client.Call("RemoteMethods.SubmitCapabilities", result, &ack)
 	if err != nil {
-		logging.Stderr("[RPC Client] Ack received: %t", ack)
+		logging.Debug("[RPC Client] Ack received: %t", ack)
 		log.Fatal(err)
 		return false, err
 	}

--- a/harvester/rpcreceiver/server.go
+++ b/harvester/rpcreceiver/server.go
@@ -23,30 +23,30 @@ type RemoteMethods struct {
 // used by attached harvesting containers to submit results back to the scheduler.
 func Run(from string, listenPort int, resultsCh chan types.ContainerReport) {
 	bindAddress := fmt.Sprintf("0.0.0.0:%d", listenPort)
-	logging.Stderr("[RPC Receiver] Starting listener: %s", from)
+	logging.Debug("[RPC Receiver] Starting listener: %s", from)
 	address, err := net.ResolveTCPAddr("tcp", bindAddress)
 	if err != nil {
 		log.Fatal(err)
 	}
-	logging.Stderr("[RPC Receiver] Bind address resolved: %s", bindAddress)
+	logging.Debug("[RPC Receiver] Bind address resolved: %s", bindAddress)
 
 	inbound, err := net.ListenTCP("tcp", address)
 	if err != nil {
 		log.Fatal(err)
 	}
-	logging.Stderr("[RPC Receiver] Listening on: %s", bindAddress)
+	logging.Debug("[RPC Receiver] Listening on: %s", bindAddress)
 
-	logging.Stderr("[RPC Receiver] Registering RemoteMethods")
+	logging.Debug("[RPC Receiver] Registering RemoteMethods")
 	remoteMethods := &RemoteMethods{resultsCh: resultsCh}
 	rpc.Register(remoteMethods)
-	logging.Stderr("[RPC Receiver] Accepting requests")
+	logging.Debug("[RPC Receiver] Accepting requests")
 	rpc.Accept(inbound)
 }
 
 // SubmitCapabilities used to submit data to the server
 func (r *RemoteMethods) SubmitCapabilities(data *types.ContainerReport, ack *Ack) error {
-	logging.Stderr("[RPC Receiver] Results for %d capabilities for container %s received from attached container TODO", len(data.Capabilities), data.ContainerID) // TODO would be useful to be able to get some info about the harvester here.
-	logging.Stderr("[RPC Receiver] Sending result to the Attached Harverster result channel")
+	logging.Debug("[RPC Receiver] Results for %d capabilities for container %s received from attached container TODO", len(data.Capabilities), data.ContainerID) // TODO would be useful to be able to get some info about the harvester here.
+	logging.Debug("[RPC Receiver] Sending result to the Attached Harverster result channel")
 	r.resultsCh <- *data
 	*ack = true
 	return nil

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -7,16 +7,18 @@ import (
 
 var (
 	// Debug flag
-	Debug bool
+	DebugEnabled bool
 )
 
 var (
 	stderr *log.Logger
-	stdout *log.Logger
 )
 
-// Stdout provides a convenient way to log to STDOUT
-func Stdout(format string, args ...interface{}) {
+// Info provides a convenient way to log to STDERR
+// Note that we use STDERR rather than STDOUT as the primary
+// purpose of this logging interface is "diagnostic messages"
+// as per POSIX
+func Info(format string, args ...interface{}) {
 	if args != nil {
 		stderr.Printf(format, args...)
 	} else {
@@ -24,9 +26,10 @@ func Stdout(format string, args ...interface{}) {
 	}
 }
 
-// Stderr provides a convenient way to log to STDERR
-func Stderr(format string, args ...interface{}) {
-	if !Debug {
+// Debug provides a convenient way to log to STDERR only when the
+// debug flag is passed
+func Debug(format string, args ...interface{}) {
+	if !DebugEnabled {
 		return
 	}
 	if args != nil {
@@ -38,6 +41,5 @@ func Stderr(format string, args ...interface{}) {
 
 func init() {
 	logProperties := log.Ldate | log.Ltime | log.Lmicroseconds
-	stderr = log.New(os.Stderr, "[lumogon] ", logProperties)
-	stdout = log.New(os.Stdout, "", logProperties)
+	stderr = log.New(os.Stderr, "[Lumogon] ", logProperties)
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -37,7 +37,7 @@ var wg sync.WaitGroup
 
 // New returns a pointer to a Scheduler
 func New(args []string, opts types.ClientOptions) *Scheduler {
-	logging.Stderr("[Scheduler] Creating scheduler")
+	logging.Debug("[Scheduler] Creating scheduler")
 	scheduler := Scheduler{
 		start: utils.GetTimestamp(),
 		args:  &args,
@@ -55,15 +55,15 @@ func New(args []string, opts types.ClientOptions) *Scheduler {
 
 // Run starts the scheduler
 func (s *Scheduler) Run(r registry.IRegistry) {
-	defer logging.Stderr("[Scheduler] Exiting")
-	logging.Stderr("[Scheduler] Running")
+	defer logging.Debug("[Scheduler] Exiting")
+	logging.Debug("[Scheduler] Running")
 	// Exit immediately if a harvester error has already been thrown
 	if s.err != nil {
 		return
 	}
 
 	timeout := s.opts.Timeout
-	logging.Stderr("[Scheduler] Creating context with timeout [%d]", timeout)
+	logging.Debug("[Scheduler] Creating context with timeout [%d]", timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 	resultsChannel := make(chan types.ContainerReport)
@@ -91,7 +91,7 @@ func (s *Scheduler) Run(r registry.IRegistry) {
 	wg.Add(1)
 	go harvester.RunDockerAPIHarvester(ctx, &wg, s.targets, r.DockerAPICapabilities(), resultsChannel, s.client)
 
-	logging.Stderr("[Scheduler] Waiting")
+	logging.Debug("[Scheduler] Waiting")
 	wg.Wait()
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -38,7 +38,7 @@ func (s Storage) Store(results map[string]types.ContainerReport) error {
 
 	err = storeResult(report, s.ConsumerURL)
 	if err != nil {
-		logging.Stderr("[Storage] Error storing report: %s ", err)
+		logging.Debug("[Storage] Error storing report: %s ", err)
 		return err
 	}
 
@@ -58,14 +58,14 @@ func formatReport(report types.Report, indent bool) ([]byte, error) {
 	}
 
 	if err != nil {
-		logging.Stderr("[Storage] error marshalling report: %s", err)
+		logging.Debug("[Storage] error marshalling report: %s", err)
 		return nil, err
 	}
 
 	resultString := string(result[:])
 	if resultString == "" {
 		errorMsg := fmt.Sprintf("[Storage] No harvesting result found")
-		logging.Stderr(errorMsg)
+		logging.Debug(errorMsg)
 		return nil, fmt.Errorf(errorMsg)
 	}
 
@@ -92,18 +92,18 @@ func storeResult(report types.Report, consumerURL string) error {
 		URL   string
 	}
 
-	logging.Stderr("[Storage] Storing report")
+	logging.Debug("[Storage] Storing report")
 	jsonStr, err := formatReport(report, false) // unindented report
 	if err != nil {
 		return err
 	}
 
 	// TODO Move HTTP Post Helper method elsewhere
-	logging.Stderr("[Storage] Posting result to: %s", consumerURL)
+	logging.Debug("[Storage] Posting result to: %s", consumerURL)
 	resp, err := http.Post(consumerURL, "application/json", bytes.NewBuffer(jsonStr))
 
 	if err != nil {
-		logging.Stderr("[Storage] Error posting result, [%s], exiting.", err)
+		logging.Debug("[Storage] Error posting result, [%s], exiting.", err)
 		os.Stderr.WriteString(fmt.Sprintf("Unable to connect to the HTTP endpoint at %s\nSending scan report to fallback: STDOUT\n", consumerURL))
 		outputResult(report)
 		os.Exit(1)
@@ -114,7 +114,7 @@ func storeResult(report types.Report, consumerURL string) error {
 	err = json.NewDecoder(resp.Body).Decode(&postResponse)
 	if err != nil {
 		errorMsg := fmt.Sprintf("[Storage] Unable to decode JSON response from server [%s], exiting.", err)
-		logging.Stderr(errorMsg)
+		logging.Debug(errorMsg)
 		os.Exit(1)
 	}
 
@@ -123,19 +123,19 @@ func storeResult(report types.Report, consumerURL string) error {
 	finalURL := utils.FormatReportURL(postResponse.URL, postResponse.Token)
 	fmt.Fprintf(os.Stdout, "\n%s\n", finalURL)
 
-	logging.Stderr("[Storage] Report stored")
+	logging.Debug("[Storage] Report stored")
 	return nil
 }
 
 // createReport returns a pointer to a types.Report built from the supplied
 // map of container IDs to types.ContainerReport.
 func createReport(results map[string]types.ContainerReport) (types.Report, error) {
-	logging.Stderr("[Storage] Marshalling JSON")
+	logging.Debug("[Storage] Marshalling JSON")
 	marshalledResult, err := json.Marshal(results)
 	if err != nil {
 		return types.Report{}, err
 	}
-	logging.Stderr("[Storage] Marshalling successful %s", string(marshalledResult))
+	logging.Debug("[Storage] Marshalling successful %s", string(marshalledResult))
 
 	report := types.Report{
 		Schema:        "http://puppet.com/lumogon/core/draft-01/schema#1",
@@ -146,6 +146,6 @@ func createReport(results map[string]types.ContainerReport) (types.Report, error
 		ReportID:      utils.GenerateUUID4(),
 		Containers:    results,
 	}
-	logging.Stderr("[Storage] Report created")
+	logging.Debug("[Storage] Report created")
 	return report, nil //TODO do we really want a pointer here?
 }


### PR DESCRIPTION
Based on some of the user feedback, the fact we don't output anything
when running a scan can cause some users to think something is amiss.
This commit adds a single message to the output for each container
scanned when running scan or report. A few considerations:

* The output goes to STDERR, with the intention that this is "diagnostic
  information" rather than output which would be usefully parsed. This
  maintains the ability to treat the actual output as JSON with JQ or
  other tooling.
* The log prefix has been changed to be Sentence case, to match the
  other tags. ie. it is not [Lumogon] rather than [lumogon].
* The logging interface was a touch confusing, in that logging.Stdout
  actually went to stderr. I've made this more abstract, ie. with Info
  and Debug.

I've purposefully not tried to delve into changing the entire logging
implementation at this point.