### PR TITLE
(MAINT) Fix output parsing from Lumogon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ vet: bootstrap
 licenses: $(GOPATH)/bin/licenses
 	@licenses  $(PACKAGE_NAME) | grep $(PACKAGE_NAME)/vendor
 
-all: clean dependencies test build image
+all: clean dependencies test build image puppet-module
 
 buildimage: clean build image
 
@@ -76,4 +76,7 @@ $(GOPATH)/bin/goconvey:
 
 bootstrap: $(GOPATH)/bin/glide $(GOPATH)/src/github.com/golang/lint/golint $(GOPATH)/bin/licenses $(GOPATH)/bin/goconvey
 
-.PHONY: build image buildimage test todo clean dependencies bootstrap licenses watch deploy
+puppet-module:
+	cd contrib/puppetlabs-lumogon; make all
+
+.PHONY: build image buildimage test todo clean dependencies bootstrap licenses watch deploy puppet-module

--- a/contrib/puppetlabs-lumogon/Makefile
+++ b/contrib/puppetlabs-lumogon/Makefile
@@ -17,4 +17,6 @@ test: dependencies
 deploy:
 	true
 
-.PHONY: dependencies bootstrap test deploy
+all: dependencies test
+
+.PHONY: dependencies bootstrap test deploy all

--- a/contrib/puppetlabs-lumogon/Makefile
+++ b/contrib/puppetlabs-lumogon/Makefile
@@ -7,9 +7,6 @@ bootstrap:
 
 dependencies:
 	bundle install
-	docker pull docker:dind
-	docker pull docker:latest
-	docker pull puppet/lumogon:latest
 
 test: dependencies
 	bundle exec rake test

--- a/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
+++ b/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'pry'
 
 Puppet::Type.type(:lumogon).provide(:lumogon) do #rubocop:disable Metrics/BlockLength
   desc "Provider for Lumogon"

--- a/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
+++ b/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
@@ -1,14 +1,16 @@
 require 'json'
+require 'pry'
 
-Puppet::Type.type(:lumogon).provide(:lumogon) do
+Puppet::Type.type(:lumogon).provide(:lumogon) do #rubocop:disable Metrics/BlockLength
   desc "Provider for Lumogon"
   commands :docker => 'docker'
 
   mk_resource_methods
 
   def self.instances #rubocop:disable Metrics/AbcSize
-    scan_report = docker(:run, '--rm', '-v', '/var/run/docker.sock:/var/run/docker.sock', 'puppet/lumogon', :scan)
-    containers = JSON.parse(scan_report)['containers']
+    cli_output = docker(:run, '--rm', '-v', '/var/run/docker.sock:/var/run/docker.sock', 'puppet/lumogon', :scan)
+    scan_report = self.parse_lumogon_report(cli_output)
+    containers = scan_report['containers']
 
     containers.collect do |c|
       container = c[1]
@@ -33,5 +35,17 @@ Puppet::Type.type(:lumogon).provide(:lumogon) do
         :labels          => container['capabilities']['label'].key?('payload') ? container['capabilities']['label']['payload'] : :absent
       })
     end
+  end
+
+  def self.parse_lumogon_report(report)
+    # Collapse output string from Puppet (STDERR and STDOUT) into a single string
+    # removing all whitespace from Lumogon Pretty Print report
+    collapsed_output = report.split("\n").map(&:strip).join("")
+
+    # Scan Output to ignore STDERR and only grab the STDOUT JSON Blob
+    json_report = collapsed_output.match(/{.+}/)[0]
+
+    # Parse and return
+    JSON.parse(json_report)
   end
 end

--- a/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
+++ b/contrib/puppetlabs-lumogon/lib/puppet/provider/lumogon/lumogon.rb
@@ -37,12 +37,15 @@ Puppet::Type.type(:lumogon).provide(:lumogon) do #rubocop:disable Metrics/BlockL
     end
   end
 
+  # Custom function to parse output from Lumogon as Puppet muxes together both
+  # STDOUT and STDERR as part of Command Execution
+  # https://github.com/puppetlabs/puppet/blob/master/lib/puppet/provider.rb#L259
   def self.parse_lumogon_report(report)
     # Collapse output string from Puppet (STDERR and STDOUT) into a single string
     # removing all whitespace from Lumogon Pretty Print report
     collapsed_output = report.split("\n").map(&:strip).join("")
 
-    # Scan Output to ignore STDERR and only grab the STDOUT JSON Blob
+    # Scan Output grab the STDOUT JSON Blob
     json_report = collapsed_output.match(/{.+}/)[0]
 
     # Parse and return


### PR DESCRIPTION
This PR adds a Regex extraction to the Puppet Provider for Lumogon. This is to address any output thrown that is *not* the JSON blob we are expecting.

