### PR TITLE
(TC-162) Adding Docker API Version to analytics

### DIFF
--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -35,6 +35,7 @@ type UserSession struct {
 	TrackingID         string       `url:"tid"`
 	ApplicationName    string       `url:"an"`
 	ApplicationVersion string       `url:"av"`
+	DockerAPIVersion   string       `url:"cd1"`
 	DisableTransmit    bool         `url:"-"`
 	HTTPClient         *http.Client `url:"-"`
 	ScreenViewMessage
@@ -53,6 +54,7 @@ func NewUserSession() *UserSession {
 		ApplicationName:    "lumogon",
 		ApplicationVersion: v.VersionString(),
 		UniqueID:           c.HostID(ctx),
+		DockerAPIVersion:   c.ServerAPIVersion(ctx),
 		DisableTransmit:    viper.GetBool("disable-analytics"),
 		HTTPClient:         http.DefaultClient,
 	}

--- a/analytics/ga_test.go
+++ b/analytics/ga_test.go
@@ -10,7 +10,7 @@ import (
 
 // Test Payload Hit Validation: https://goo.gl/4E4ISD
 func TestScreenViewPostMeasurement(t *testing.T) {
-	validScreenViewHitURL, _ := url.Parse("https://www.google-analytics.com/collect?v=1&t=screenview&tid=UA-12345678-9&cid=testid&an=lumogon&av=testversion&cd=testscreen")
+	validScreenViewHitURL, _ := url.Parse("https://www.google-analytics.com/collect?v=1&t=screenview&tid=UA-12345678-9&cid=testid&an=lumogon&av=testversion&cd=testscreen&cd1=1.27")
 	u := *MockUserSession()
 	u.Type = "screenview"
 	u.ScreenName = "testscreen"
@@ -32,7 +32,7 @@ func TestScreenViewPostMeasurement(t *testing.T) {
 
 // Test Payload Hit Validation: https://goo.gl/7mC9TI
 func TestEventPostMeasurement(t *testing.T) {
-	validEventHitURL, _ := url.Parse("https://www.google-analytics.com/collect?v=1&t=event&tid=UA-12345678-9&cid=testid&an=lumogon&av=testversion&ec=testcategory&ea=testaction")
+	validEventHitURL, _ := url.Parse("https://www.google-analytics.com/collect?v=1&t=event&tid=UA-12345678-9&cid=testid&an=lumogon&av=testversion&ec=testcategory&ea=testaction&cd1=1.27")
 	u := *MockUserSession()
 	u.Type = "event"
 	u.Action = "testaction"

--- a/dockeradapter/dockeradapter.go
+++ b/dockeradapter/dockeradapter.go
@@ -62,6 +62,7 @@ type Executor interface {
 // HostInspector interface exposes methods required to inspect a docker host
 type HostInspector interface {
 	HostID(ctx context.Context) string
+	ServerAPIVersion(ctx context.Context) string
 }
 
 // ImageInspectorPuller interface exposes methods required to both pull and
@@ -161,6 +162,11 @@ func (c *concreteDockerClient) ContainerInspect(ctx context.Context, containerID
 func (c *concreteDockerClient) HostID(ctx context.Context) string {
 	resp, _ := c.Client.Info(ctx)
 	return resp.ID
+}
+
+func (c *concreteDockerClient) ServerAPIVersion(ctx context.Context) string {
+	resp, _ := c.Client.ServerVersion(ctx)
+	return resp.APIVersion
 }
 
 func (c *concreteDockerClient) ContainerExecCreate(ctx context.Context, containerID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.IDResponse, error) {


### PR DESCRIPTION
This PR updates the Google Analytics endpoint to collect the deployed version of Docker Lumogon is being used against. This will help us make informed decisions on where we place engineering efforts as we develop additional capabilities.