### PR TITLE
(MAINT) fix reference to Dockerfile in deploy

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -51,7 +51,7 @@ docker login -u $DOCKER_USER -p $DOCKER_PASSWORD > /dev/null 2>&1
 
 # Build the image
 echo "Building $DOCKER_IMAGE..."
-docker build -t ${DOCKER_IMAGE} -f Dockerfile.build $DIR/..
+docker build -t ${DOCKER_IMAGE} -f Dockerfile $DIR/..
 
 # Tag the image
 echo "Tagging $DOCKER_FINAL_NAME"

--- a/script/deploy
+++ b/script/deploy
@@ -51,7 +51,7 @@ docker login -u $DOCKER_USER -p $DOCKER_PASSWORD > /dev/null 2>&1
 
 # Build the image
 echo "Building $DOCKER_IMAGE..."
-docker build -t ${DOCKER_IMAGE} -f Dockerfile $DIR/..
+docker build -t ${DOCKER_IMAGE} $DIR/..
 
 # Tag the image
 echo "Tagging $DOCKER_FINAL_NAME"


### PR DESCRIPTION
This commit fixes the outdated reference to `Dockerfile.build` in the deploy script, it now points to Dockerfile.

It should resolve the deploy failure introduced by #44 