### PR TITLE
(MAINT) Install docker-ce for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - secure: Q5+WSF1b7tBzaVKWIIAOT4ItlcSj38eVMw5XAWkpw4XRaO1lu1awuvsx2XBDlZaLdcvm6S45HbM/6wX4/ZoBcv0rVx5Bd4ojranXEby4aIwPAxWx4hJ2plIgoQGWcRH576Nh7WumpW+kBllpYI8pcziW6bAA59SsX9OESBsmTK4+dSR8efBWUYQzTccsU0X+x+5HEot2wb/4j6/Xpis1zsMSEWL33j/KLSp3e4CE4DjoFONr3UiSII3RAmHjus/4C47S7bx1JGv3sZgQ96pVt0zZO4Au1Nn+R85caAJqm31Vx7mEDENYnLbfAKuGXWoRzV+1odFDsk5UUwRGEgc+w9+r0nrFfCn22NgCk5R5smmNr7yXbpt3ECLfuEglTkeD6qpyOckf5rgY0y834iQURYhEJPnh6v8f2C1XntDYsgyb0ni9Um6D2CYM4hp7yWw0aW+59Ia5cs/E5JgYIqsHuiAyoVuVcmnMXHhGwD+G8YhGCpahe1u0aNRGifdYmatzBXR8iGUh/RbEpXdIXQmpvgR2bFcfnuKIbV/WIVjejzxiFJmjSBYKs93J5BBJww7W8v2+e+WuDs5uiLpYtQFMeqaAua4NwxyQlyEKgAYTCQfy1DsjkKhWiTmlJ2b05LHE30RRKHYVbJRoW51xsTvE43wzmtAQ63vg5PUvwh6xnKs=
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 matrix:
   include:
   - go: 1.8


### PR DESCRIPTION
:cherries:-pick to repair Travis CI builds due to upstream package pull.

/cc #52 