### PR TITLE
(DI-489) (TC-155) Add fallback harvester removal ability for APIs < 1.25 (Engine < 1.13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     language: go
     install: make bootstrap
     script:
-    - make dependencies test
+    - make vendor test
   - language: ruby
     rvm: 2.3.4
     cache: bundler
@@ -28,7 +28,7 @@ matrix:
     bundler_args: --without development
     env: PUPPET_GEM_VERSION="~> 4.0"
     install: cd contrib/puppetlabs-lumogon && make bootstrap
-    script: make dependencies test
+    script: make vendor test
 deploy:
 - provider: script
   script: make deploy

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,7 @@ TESTLDFLAGS += -s
 GOARCH ?= amd64
 GOOS ?= linux
 
-
-clean:
-	rm -rf bin/*;
-	go clean -i ./...
+build: bin/lumogon
 
 dependencies: bootstrap
 	glide install
@@ -34,11 +31,14 @@ test: lint vet
 watch: bootstrap
 	goconvey
 
-bin/lumogon:
+bin/lumogon: dependencies
 	mkdir -p bin
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -a -ldflags '$(LDFLAGS)' -o bin/lumogon lumogon.go
 
-build: bin/lumogon bootstrap
+
+clean:
+	rm -rf bin/*;
+	go clean -i ./...
 
 image:
 	docker build -t $(CONTAINER_NAME) .

--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -44,7 +44,7 @@ type UserSession struct {
 // NewUserSession provides a setup UserSession struct with sane defaults
 func NewUserSession() *UserSession {
 	v := version.Version
-	host, _, _ := dockeradapter.DockerEnvvars()
+	host, _, _ := dockeradapter.DockerConfig()
 	serverAPIVersion, uniqueID, _ := dockeradapter.ServerInfo(host)
 
 	return &UserSession{

--- a/analytics/ga.go
+++ b/analytics/ga.go
@@ -1,7 +1,6 @@
 package analytics
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 
@@ -45,17 +44,16 @@ type UserSession struct {
 // NewUserSession provides a setup UserSession struct with sane defaults
 func NewUserSession() *UserSession {
 	v := version.Version
-	ctx := context.Background()
-	c, _ := dockeradapter.New()
-	dv, _ := c.ServerVersion(ctx)
+	host, _, _ := dockeradapter.DockerEnvvars()
+	serverAPIVersion, uniqueID, _ := dockeradapter.ServerInfo(host)
 
 	return &UserSession{
 		ProtocolVersion:    1,
 		TrackingID:         "UA-54263865-7",
 		ApplicationName:    "lumogon",
 		ApplicationVersion: v.VersionString(),
-		UniqueID:           c.HostID(ctx),
-		DockerAPIVersion:   dv.APIVersion,
+		UniqueID:           uniqueID,
+		DockerAPIVersion:   serverAPIVersion,
 		DisableTransmit:    viper.GetBool("disable-analytics"),
 		HTTPClient:         http.DefaultClient,
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -15,7 +15,7 @@ var results map[string]types.ContainerReport
 // RunCollector starts the collector which will block on reading all
 // expected ContainerReports from the results channel, before sending
 // them to the ReportStorage backend.
-func RunCollector(ctx context.Context, wg *sync.WaitGroup, expectedResults int, resultsCh chan types.ContainerReport, backend storage.ReportStorage) error {
+func RunCollector(ctx context.Context, wg *sync.WaitGroup, expectedResults int, resultsCh chan types.ContainerReport, backend storage.ReportStorage, reportID string) error {
 	defer logging.Debug("[Collector] Exiting")
 	defer wg.Done()
 
@@ -47,8 +47,8 @@ func RunCollector(ctx context.Context, wg *sync.WaitGroup, expectedResults int, 
 	}
 	resultsWg.Wait()
 
-	logging.Debug("[Collector] Generating report")
-	err = backend.Store(results)
+	logging.Debug("[Collector] Generating report: %s", reportID)
+	err = backend.Store(results, reportID)
 	return err
 }
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -19,8 +19,9 @@ var storedReport map[string]types.ContainerReport
 
 type MockStorage struct{}
 
-func (m MockStorage) Store(containerReports map[string]types.ContainerReport) error {
+func (m MockStorage) Store(containerReports map[string]types.ContainerReport, reportID string) error {
 	fmt.Println("entering store")
+	fmt.Printf("storing reportID: %s\n", reportID)
 	fmt.Printf("attempting to store: %v\n", containerReports)
 	defer fmt.Println("exiting store")
 	storedReport = containerReports
@@ -85,7 +86,7 @@ func Test_collector(t *testing.T) {
 			go func() {
 				t.Logf("starting Collector, expectedResults [%d]", test.expectedResults)
 				defer t.Logf("exiting Collector")
-				RunCollector(testCtx, &wg, test.expectedResults, r, MockStorage{})
+				RunCollector(testCtx, &wg, test.expectedResults, r, MockStorage{}, "dummy_report_id")
 				c <- nil
 			}()
 

--- a/contrib/puppetlabs-lumogon/.rubocop.yml
+++ b/contrib/puppetlabs-lumogon/.rubocop.yml
@@ -125,7 +125,7 @@ Lint/Void:
 Layout/AccessModifierIndentation:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/Alias:
@@ -161,7 +161,7 @@ Layout/CaseIndentation:
 Style/CharacterLiteral:
   Enabled: false
 
-Style/ClassAndModuleCamelCase:
+Naming/ClassAndModuleCamelCase:
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -261,7 +261,7 @@ Style/CommentAnnotation:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Style/ConstantName:
+Naming/ConstantName:
   Enabled: false
 
 Style/Documentation:
@@ -364,7 +364,7 @@ Style/UnlessElse:
 Style/VariableInterpolation:
   Enabled: false
 
-Style/VariableName:
+Naming/VariableName:
   Enabled: false
 
 Style/WhileUntilDo:
@@ -373,7 +373,7 @@ Style/WhileUntilDo:
 Style/EvenOdd:
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
 Style/For:
@@ -382,7 +382,7 @@ Style/For:
 Style/Lambda:
   Enabled: false
 
-Style/MethodName:
+Naming/MethodName:
   Enabled: false
 
 Style/MultilineTernaryOperator:
@@ -418,7 +418,7 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameter:
   Enabled: false
 
 Style/ParenthesesAroundCondition:
@@ -430,7 +430,7 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   Enabled: false
 
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 Style/RedundantException:

--- a/contrib/puppetlabs-lumogon/Makefile
+++ b/contrib/puppetlabs-lumogon/Makefile
@@ -5,15 +5,15 @@ bootstrap:
 	sudo apt-get update
 	sudo apt-get install docker-ce
 
-dependencies:
+vendor:
 	bundle install
 
-test: dependencies
+test: vendor
 	bundle exec rake test
 
 deploy:
 	true
 
-all: dependencies test
+all: vendor test
 
-.PHONY: dependencies bootstrap test deploy all
+.PHONY: vendor bootstrap test deploy all

--- a/dockeradapter/dockeradapter.go
+++ b/dockeradapter/dockeradapter.go
@@ -73,9 +73,9 @@ type ImageInspectorPuller interface {
 	ImagePuller
 }
 
-// Creator interface exposes methods required to create a container
+// Creator interface exposes methods required to create an attached container
 type Creator interface {
-	ContainerCreate(ctx context.Context, command []string, envvars []string, image string, binds []string, links []string, kernelCapabilities []string, pidMode string, containerName string, autoRemove bool) (dockercontainer.ContainerCreateCreatedBody, error)
+	ContainerCreate(ctx context.Context, command []string, envvars []string, image string, binds []string, links []string, kernelCapabilities []string, pidMode string, containerName string, autoRemove bool, labels map[string]string) (dockercontainer.ContainerCreateCreatedBody, error)
 }
 
 // Remover interface exposes methods required to remove a container
@@ -204,11 +204,12 @@ func (c *concreteDockerClient) ContainerExecInspect(ctx context.Context, execID 
 
 // ContainerCreate creates a container with the supplied subset of the Docker
 // API configuration
-func (c *concreteDockerClient) ContainerCreate(ctx context.Context, command []string, envvars []string, image string, binds []string, links []string, kernelCapabilities []string, pidMode string, containerName string, autoRemove bool) (dockercontainer.ContainerCreateCreatedBody, error) {
+func (c *concreteDockerClient) ContainerCreate(ctx context.Context, command []string, envvars []string, image string, binds []string, links []string, kernelCapabilities []string, pidMode string, containerName string, autoRemove bool, labels map[string]string) (dockercontainer.ContainerCreateCreatedBody, error) {
 	config := dockercontainer.Config{
-		Image: image,
-		Cmd:   command,
-		Env:   envvars,
+		Image:  image,
+		Cmd:    command,
+		Env:    envvars,
+		Labels: labels,
 	}
 
 	attachPid := dockercontainer.PidMode(pidMode)

--- a/dockeradapter/dockeradapter.go
+++ b/dockeradapter/dockeradapter.go
@@ -16,7 +16,9 @@ import (
 )
 
 // MinSupportedAPIVersion is the lowest Docker API version that Lumogon supports
-// Docker API Version 1.21 - Docker Engine 1.9.x
+// Docker API Version 1.21 - Docker Engine 1.10.x
+// - for support < 1.21 need to be able to identify the scheduler container so it can be excluded from results
+// - for support < 1.20 need to use an alternative to copy when detecting the target containers OS
 const MinSupportedAPIVersion = "1.21"
 
 // Client is a Docker (currently local) ContainerRuntime
@@ -33,6 +35,7 @@ type Client interface {
 	HostInspector
 	CopyFrom
 	Diff
+	ServerAPIVersion() string
 }
 
 // Harvester interface exposes methods used by Capabilties Harvest functions
@@ -216,6 +219,11 @@ func ServerInfo(host string) (string, string, error) {
 	}
 
 	return version.APIVersion, resp.ID, nil
+}
+
+// ImageInspect inspects that requested image
+func (c *concreteDockerClient) ServerAPIVersion() string {
+	return c.APIVersion
 }
 
 // ImageInspect inspects that requested image

--- a/dockeradapter/versions/versions.go
+++ b/dockeradapter/versions/versions.go
@@ -1,0 +1,10 @@
+package versions
+
+import (
+	"github.com/docker/docker/api/types/versions"
+)
+
+// LessThan checks if a version is less than another
+func LessThan(v, other string) bool {
+	return versions.LessThan(v, other)
+}

--- a/harvester/attached.go
+++ b/harvester/attached.go
@@ -20,7 +20,7 @@ import (
 // channel, when a result is received it will attempt to remove that associated
 // attached container which performed the harvest before sending the result to the
 // collector via the main results channel, resultsCh.
-func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*types.TargetContainer, capabilities []types.AttachedCapability, resultsCh chan types.ContainerReport, opts types.ClientOptions, client dockeradapter.Client) error {
+func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*types.TargetContainer, capabilities []types.AttachedCapability, resultsCh chan types.ContainerReport, opts types.ClientOptions, client dockeradapter.Client, reportID string) error {
 	defer logging.Debug("[Attached Harvester] Exiting")
 	defer wg.Done()
 	logging.Debug("[Attached Harvester] Running")
@@ -57,7 +57,7 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 
 	logging.Debug("[Attached Harvester] Creating [%d] harvesting containers", len(validTargets))
 	for _, target := range validTargets {
-		go createAndRunHarvester(ctx, client, *target, opts, rpcReceiverResultsCh)
+		go createAndRunHarvester(ctx, client, *target, opts, rpcReceiverResultsCh, reportID)
 	}
 
 	doneChannel := make(chan int)
@@ -86,9 +86,9 @@ func RunAttachedHarvester(ctx context.Context, wg *sync.WaitGroup, targets []*ty
 // createAndRunHarvester creates and runs a container attached to the namespace of the target
 // container which will run the harvest command to run the harvest functions from any registered
 // AttachedCapabilities.
-func createAndRunHarvester(ctx context.Context, client dockeradapter.Client, target types.TargetContainer, opts types.ClientOptions, rpcReceiverResultsCh chan types.ContainerReport) {
+func createAndRunHarvester(ctx context.Context, client dockeradapter.Client, target types.TargetContainer, opts types.ClientOptions, rpcReceiverResultsCh chan types.ContainerReport, reportID string) {
 	logging.Debug("[Attached Harvester] Creating attached container for target %s", target)
-	harvester := NewAttachedContainer(client, types.ClientOptions{KeepHarvesters: opts.KeepHarvesters})
+	harvester := NewAttachedContainer(client, types.ClientOptions{KeepHarvesters: opts.KeepHarvesters}, reportID)
 	// TODO get image name from the current container or set alternate default for non-container use
 	harvester.GetImage("puppet/lumogon")
 	harvester.Attach(target)

--- a/harvester/attachedcontainer.go
+++ b/harvester/attachedcontainer.go
@@ -111,8 +111,13 @@ func (a *AttachedContainer) createContainer() {
 	schedulerAliasHostname := "scheduler"
 	// Add an aliass for the scheduler to each harvester
 	links := []string{fmt.Sprintf("%s:%s", a.schedulerID, schedulerAliasHostname)}
+	labels := map[string]string{"lumogon_attached_container": "true",
+		"lumogon_attached_timestamp":   a.start,
+		"lumogon_attached_target_name": a.target.Name,
+		"lumogon_attached_target_id":   a.target.ID,
+		"lumogon_attached_target_osx":  a.target.OSID}
 
-	container, err := a.client.ContainerCreate(a.ctx, command, envvars, a.imageName, binds, links, kernelCapabilities, pidMode, a.name, !a.keepHarvester)
+	container, err := a.client.ContainerCreate(a.ctx, command, envvars, a.imageName, binds, links, kernelCapabilities, pidMode, a.name, !a.keepHarvester, labels)
 	if err != nil {
 		logging.Debug("[AttachedContainer] Error creating container: %s", err)
 		a.err = err

--- a/harvester/attachedcontainer.go
+++ b/harvester/attachedcontainer.go
@@ -16,19 +16,20 @@ import (
 // AttachedContainer is a container attached to a running target container
 // used to gather capability information
 type AttachedContainer struct {
-	imageName     string
-	id            string
-	name          string
-	start         string
-	end           string
-	schedulerID   string
-	ctx           context.Context
-	result        *types.ContainerReport
-	target        types.TargetContainer
-	containerBody *dockercontainer.ContainerCreateCreatedBody
-	client        dockeradapter.Client
-	keepHarvester bool
-	err           error
+	imageName         string
+	id                string
+	name              string
+	start             string
+	end               string
+	reportID          string
+	schedulerHostname string
+	ctx               context.Context
+	result            *types.ContainerReport
+	target            types.TargetContainer
+	containerBody     *dockercontainer.ContainerCreateCreatedBody
+	client            dockeradapter.Client
+	keepHarvester     bool
+	err               error
 }
 
 // AttachedContainerInterface interface exposes Harvester lifecycle functions
@@ -39,17 +40,18 @@ type AttachedContainerInterface interface {
 }
 
 // NewAttachedContainer returns a pointer to a harvester AttachedContainer
-func NewAttachedContainer(client dockeradapter.Client, opts types.ClientOptions) *AttachedContainer {
+func NewAttachedContainer(client dockeradapter.Client, opts types.ClientOptions, reportID string) *AttachedContainer {
 
 	hostname, _ := os.Hostname()
 
 	attachedContainer := &AttachedContainer{
-		start:         utils.GetTimestamp(),
-		name:          utils.GetRandomName("lumogon_"),
-		client:        client,
-		schedulerID:   hostname,
-		keepHarvester: opts.KeepHarvesters,
-		ctx:           context.Background(),
+		start:             utils.GetTimestamp(),
+		name:              utils.GetRandomName("lumogon_"),
+		client:            client,
+		reportID:          reportID,
+		schedulerHostname: hostname,
+		keepHarvester:     opts.KeepHarvesters,
+		ctx:               context.Background(),
 	}
 
 	return attachedContainer
@@ -109,9 +111,10 @@ func (a *AttachedContainer) createContainer() {
 	kernelCapabilities := []string{"sys_admin"} // TODO - Need to investigate making the harvester immutable? minimise risk of altering attached namespace
 	pidMode := fmt.Sprintf("container:%s", a.target.ID)
 	schedulerAliasHostname := "scheduler"
-	// Add an aliass for the scheduler to each harvester
-	links := []string{fmt.Sprintf("%s:%s", a.schedulerID, schedulerAliasHostname)}
-	labels := map[string]string{"lumogon_attached_container": "true",
+	// Add an aliass for the scheduler to each harvester to allow it to connect
+	// to its RPC server
+	links := []string{fmt.Sprintf("%s:%s", a.schedulerHostname, schedulerAliasHostname)}
+	labels := map[string]string{"lumogon_report_id": a.reportID,
 		"lumogon_attached_timestamp":   a.start,
 		"lumogon_attached_target_name": a.target.Name,
 		"lumogon_attached_target_id":   a.target.ID,


### PR DESCRIPTION
This PR adds a fallback `CleanupHarvesters` function that uses labels to identify attached harvester containers and will forcefully delete any matching containers on completion of a successfully scan or report.

It also performs a more graceful API negotiation when connecting to the Docker server, first connecting without specifying an API version so that the Server version can be established, and then creating the main client connection with that discovered API version as long as it is greater than the minimum supported version.

You can test this by running against a Docker engine 1.12 or earlier, for example to setup on Centos 7:
```
yum -y update
yum -y install yum-utils
yum-config-manager --add-repo https://yum.dockerproject.org/repo/main/centos/7
yum -y update
# yum search --showduplicates docker-engine
yum -y --nogpgcheck install docker-engine-1.12.6-1.el7.centos.x86_64
service docker start
```