### PR TITLE
(DI-489) Add basic container info capability

### DIFF
--- a/capabilities/container/container.go
+++ b/capabilities/container/container.go
@@ -1,0 +1,113 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/puppetlabs/lumogon/capabilities/payloadfilter"
+	"github.com/puppetlabs/lumogon/capabilities/registry"
+	"github.com/puppetlabs/lumogon/dockeradapter"
+	"github.com/puppetlabs/lumogon/logging"
+	"github.com/puppetlabs/lumogon/types"
+)
+
+var containerDescription = `The 'container' capability captures detailed container information`
+
+var containerCapability = dockeradapter.DockerAPICapability{
+	Capability: types.Capability{
+		Schema:      "http://puppet.com/lumogon/capability/container/draft-01/schema#1",
+		Title:       "Container Information",
+		Name:        "container",
+		Description: containerDescription,
+		Type:        "dockerapi",
+		Payload:     nil,
+		SupportedOS: map[string]int{"all": 1},
+	},
+	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
+		logging.Debug("[Container Info] Harvesting container information associated with %s [%s]", target.Name, target.ID)
+		capability.HarvestID = id
+
+		version, err := InspectContainer(client, target.ID)
+		if err != nil {
+			capability.PayloadError(err.Error())
+			return
+		}
+
+		filtered, _ := payloadfilter.Filter(version)
+
+		capability.Payload = filtered
+	},
+}
+
+// InspectContainer Extracts and returns a formatted map[string]interface{} containing
+// a subset of information returned by ContainerInspect
+func InspectContainer(client dockeradapter.Harvester, targetID string) (map[string]interface{}, error) {
+	ctx := context.Background()
+	c, err := client.ContainerInspect(ctx, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO - **IMPORTANT** this contains only a subset of the information available
+	// it explicitly avoids including any structured data (ports/mappings etc) pending
+	// support in the UI, it also avoids any config that could potentially contain
+	// sensitive data.
+
+	result := map[string]interface{}{
+		"Hostname":           c.Config.Hostname,
+		"Domainname":         c.Config.Domainname,
+		"User":               c.Config.User,
+		"Image":              c.Config.Image,
+		"AttachStdin":        fmt.Sprintf("%t", c.Config.AttachStdin),
+		"AttachStdout":       fmt.Sprintf("%t", c.Config.AttachStdout),
+		"AttachStderr":       fmt.Sprintf("%t", c.Config.AttachStderr),
+		"Tty":                fmt.Sprintf("%t", c.Config.Tty),
+		"OpenStdin":          fmt.Sprintf("%t", c.Config.OpenStdin),
+		"StdinOnce":          fmt.Sprintf("%t", c.Config.StdinOnce),
+		"Privileged":         fmt.Sprintf("%t", c.HostConfig.Privileged),
+		"PublishAllPorts":    fmt.Sprintf("%t", c.HostConfig.PublishAllPorts),
+		"ReadonlyRootfs":     fmt.Sprintf("%t", c.HostConfig.ReadonlyRootfs),
+		"ShmSize":            fmt.Sprintf("%d", c.HostConfig.ShmSize),
+		"CapAdd":             strings.Join(c.HostConfig.CapAdd, ", "),
+		"CapDrop":            strings.Join(c.HostConfig.CapDrop, ", "),
+		"Runtime":            c.HostConfig.Runtime,
+		"CPUShares":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUShares),
+		"Memory":             fmt.Sprintf("%d", c.HostConfig.Resources.Memory),
+		"NanoCPUs":           fmt.Sprintf("%d", c.HostConfig.Resources.NanoCPUs),
+		"CPUPeriod":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUPeriod),
+		"CPUQuota":           fmt.Sprintf("%d", c.HostConfig.Resources.CPUQuota),
+		"CPURealtimePeriod":  fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimePeriod),
+		"CPURealtimeRuntime": fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimeRuntime),
+		"CpusetCpus":         c.HostConfig.Resources.CpusetCpus,
+		"CpusetMems":         c.HostConfig.Resources.CpusetMems,
+		"DiskQuota":          fmt.Sprintf("%d", c.HostConfig.Resources.DiskQuota),
+		"KernelMemory":       fmt.Sprintf("%d", c.HostConfig.Resources.KernelMemory),
+		"MemoryReservation":  fmt.Sprintf("%d", c.HostConfig.Resources.MemoryReservation),
+		"MemorySwap":         fmt.Sprintf("%d", c.HostConfig.Resources.MemorySwap),
+		"MemorySwappiness":   fmt.Sprintf("%d", *c.HostConfig.Resources.MemorySwappiness),
+		"OomKillDisable":     fmt.Sprintf("%t", *c.HostConfig.Resources.OomKillDisable),
+		"PidsLimit":          fmt.Sprintf("%d", c.HostConfig.Resources.PidsLimit),
+	}
+
+	logging.Debug("[Container Info] Harvested [%+v]", result)
+
+	return result, nil
+}
+
+func ports(m nat.PortSet) []string {
+	keys := make([]string, len(m))
+
+	i := 0
+	for k := range m {
+		keys[i] = k.Port()
+		i++
+	}
+	return keys
+}
+
+func init() {
+	logging.Debug("[Container Info] Initialising capability: %s", containerCapability.Title)
+	registry.Registry.Add(containerCapability)
+}

--- a/capabilities/container/container.go
+++ b/capabilities/container/container.go
@@ -26,7 +26,7 @@ var containerCapability = dockeradapter.DockerAPICapability{
 		SupportedOS: map[string]int{"all": 1},
 	},
 	Harvest: func(capability *dockeradapter.DockerAPICapability, client dockeradapter.Harvester, id string, target types.TargetContainer) {
-		logging.Debug("[Container Info] Harvesting container information associated with %s [%s]", target.Name, target.ID)
+		logging.Debug("[Container Info] Harvesting container information associated with %s [%s]\n", target.Name, target.ID)
 		capability.HarvestID = id
 
 		version, err := InspectContainer(client, target.ID)
@@ -56,42 +56,42 @@ func InspectContainer(client dockeradapter.Harvester, targetID string) (map[stri
 	// sensitive data.
 
 	result := map[string]interface{}{
-		"Hostname":           c.Config.Hostname,
-		"Domainname":         c.Config.Domainname,
-		"User":               c.Config.User,
-		"Image":              c.Config.Image,
-		"AttachStdin":        fmt.Sprintf("%t", c.Config.AttachStdin),
-		"AttachStdout":       fmt.Sprintf("%t", c.Config.AttachStdout),
-		"AttachStderr":       fmt.Sprintf("%t", c.Config.AttachStderr),
-		"Tty":                fmt.Sprintf("%t", c.Config.Tty),
-		"OpenStdin":          fmt.Sprintf("%t", c.Config.OpenStdin),
-		"StdinOnce":          fmt.Sprintf("%t", c.Config.StdinOnce),
-		"Privileged":         fmt.Sprintf("%t", c.HostConfig.Privileged),
-		"PublishAllPorts":    fmt.Sprintf("%t", c.HostConfig.PublishAllPorts),
-		"ReadonlyRootfs":     fmt.Sprintf("%t", c.HostConfig.ReadonlyRootfs),
-		"ShmSize":            fmt.Sprintf("%d", c.HostConfig.ShmSize),
-		"CapAdd":             strings.Join(c.HostConfig.CapAdd, ", "),
-		"CapDrop":            strings.Join(c.HostConfig.CapDrop, ", "),
-		"Runtime":            c.HostConfig.Runtime,
-		"CPUShares":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUShares),
-		"Memory":             fmt.Sprintf("%d", c.HostConfig.Resources.Memory),
-		"NanoCPUs":           fmt.Sprintf("%d", c.HostConfig.Resources.NanoCPUs),
-		"CPUPeriod":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUPeriod),
-		"CPUQuota":           fmt.Sprintf("%d", c.HostConfig.Resources.CPUQuota),
-		"CPURealtimePeriod":  fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimePeriod),
-		"CPURealtimeRuntime": fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimeRuntime),
-		"CpusetCpus":         c.HostConfig.Resources.CpusetCpus,
-		"CpusetMems":         c.HostConfig.Resources.CpusetMems,
-		"DiskQuota":          fmt.Sprintf("%d", c.HostConfig.Resources.DiskQuota),
-		"KernelMemory":       fmt.Sprintf("%d", c.HostConfig.Resources.KernelMemory),
-		"MemoryReservation":  fmt.Sprintf("%d", c.HostConfig.Resources.MemoryReservation),
-		"MemorySwap":         fmt.Sprintf("%d", c.HostConfig.Resources.MemorySwap),
-		"MemorySwappiness":   fmt.Sprintf("%d", *c.HostConfig.Resources.MemorySwappiness),
-		"OomKillDisable":     fmt.Sprintf("%t", *c.HostConfig.Resources.OomKillDisable),
-		"PidsLimit":          fmt.Sprintf("%d", c.HostConfig.Resources.PidsLimit),
+		"hostname":           c.Config.Hostname,
+		"domainname":         c.Config.Domainname,
+		"user":               c.Config.User,
+		"image":              c.Config.Image,
+		"attachstdin":        fmt.Sprintf("%t", c.Config.AttachStdin),
+		"attachstdout":       fmt.Sprintf("%t", c.Config.AttachStdout),
+		"attachstderr":       fmt.Sprintf("%t", c.Config.AttachStderr),
+		"tty":                fmt.Sprintf("%t", c.Config.Tty),
+		"openstdin":          fmt.Sprintf("%t", c.Config.OpenStdin),
+		"stdinonce":          fmt.Sprintf("%t", c.Config.StdinOnce),
+		"privileged":         fmt.Sprintf("%t", c.HostConfig.Privileged),
+		"publishallports":    fmt.Sprintf("%t", c.HostConfig.PublishAllPorts),
+		"readonlyrootfs":     fmt.Sprintf("%t", c.HostConfig.ReadonlyRootfs),
+		"shmsize":            fmt.Sprintf("%d", c.HostConfig.ShmSize),
+		"capadd":             strings.Join(c.HostConfig.CapAdd, ", "),
+		"capdrop":            strings.Join(c.HostConfig.CapDrop, ", "),
+		"runtime":            c.HostConfig.Runtime,
+		"cpushares":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUShares),
+		"memory":             fmt.Sprintf("%d", c.HostConfig.Resources.Memory),
+		"nanocpus":           fmt.Sprintf("%d", c.HostConfig.Resources.NanoCPUs),
+		"cpuperiod":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUPeriod),
+		"cpuquota":           fmt.Sprintf("%d", c.HostConfig.Resources.CPUQuota),
+		"cpurealtimeperiod":  fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimePeriod),
+		"cpurealtimeruntime": fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimeRuntime),
+		"cpusetcpus":         c.HostConfig.Resources.CpusetCpus,
+		"cpusetmems":         c.HostConfig.Resources.CpusetMems,
+		"diskquota":          fmt.Sprintf("%d", c.HostConfig.Resources.DiskQuota),
+		"kernelmemory":       fmt.Sprintf("%d", c.HostConfig.Resources.KernelMemory),
+		"memoryreservation":  fmt.Sprintf("%d", c.HostConfig.Resources.MemoryReservation),
+		"memoryswap":         fmt.Sprintf("%d", c.HostConfig.Resources.MemorySwap),
+		"memoryswappiness":   fmt.Sprintf("%d", *c.HostConfig.Resources.MemorySwappiness),
+		"oomkilldisable":     fmt.Sprintf("%t", *c.HostConfig.Resources.OomKillDisable),
+		"pidslimit":          fmt.Sprintf("%d", c.HostConfig.Resources.PidsLimit),
 	}
 
-	logging.Debug("[Container Info] Harvested [%+v]", result)
+	logging.Debug("[Container Info] Harvested [%+v]\n", result)
 
 	return result, nil
 }
@@ -108,6 +108,6 @@ func ports(m nat.PortSet) []string {
 }
 
 func init() {
-	logging.Debug("[Container Info] Initialising capability: %s", containerCapability.Title)
+	logging.Debug("[Container Info] Initialising capability: %s\n", containerCapability.Title)
 	registry.Registry.Add(containerCapability)
 }

--- a/capabilities/container/container.go
+++ b/capabilities/container/container.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/puppetlabs/lumogon/capabilities/payloadfilter"
 	"github.com/puppetlabs/lumogon/capabilities/registry"
 	"github.com/puppetlabs/lumogon/dockeradapter"
@@ -29,13 +28,13 @@ var containerCapability = dockeradapter.DockerAPICapability{
 		logging.Debug("[Container Info] Harvesting container information associated with %s [%s]\n", target.Name, target.ID)
 		capability.HarvestID = id
 
-		version, err := InspectContainer(client, target.ID)
+		containerInfo, err := InspectContainer(client, target.ID)
 		if err != nil {
 			capability.PayloadError(err.Error())
 			return
 		}
 
-		filtered, _ := payloadfilter.Filter(version)
+		filtered, _ := payloadfilter.Filter(containerInfo)
 
 		capability.Payload = filtered
 	},
@@ -69,42 +68,31 @@ func InspectContainer(client dockeradapter.Harvester, targetID string) (map[stri
 		"privileged":         fmt.Sprintf("%t", c.HostConfig.Privileged),
 		"publishallports":    fmt.Sprintf("%t", c.HostConfig.PublishAllPorts),
 		"readonlyrootfs":     fmt.Sprintf("%t", c.HostConfig.ReadonlyRootfs),
-		"shmsize":            fmt.Sprintf("%d", c.HostConfig.ShmSize),
+		"shmsize":            c.HostConfig.ShmSize,
 		"capadd":             strings.Join(c.HostConfig.CapAdd, ", "),
 		"capdrop":            strings.Join(c.HostConfig.CapDrop, ", "),
 		"runtime":            c.HostConfig.Runtime,
-		"cpushares":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUShares),
-		"memory":             fmt.Sprintf("%d", c.HostConfig.Resources.Memory),
-		"nanocpus":           fmt.Sprintf("%d", c.HostConfig.Resources.NanoCPUs),
-		"cpuperiod":          fmt.Sprintf("%d", c.HostConfig.Resources.CPUPeriod),
-		"cpuquota":           fmt.Sprintf("%d", c.HostConfig.Resources.CPUQuota),
-		"cpurealtimeperiod":  fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimePeriod),
-		"cpurealtimeruntime": fmt.Sprintf("%d", c.HostConfig.Resources.CPURealtimeRuntime),
+		"cpushares":          c.HostConfig.Resources.CPUShares,
+		"memory":             c.HostConfig.Resources.Memory,
+		"nanocpus":           c.HostConfig.Resources.NanoCPUs,
+		"cpuperiod":          c.HostConfig.Resources.CPUPeriod,
+		"cpuquota":           c.HostConfig.Resources.CPUQuota,
+		"cpurealtimeperiod":  c.HostConfig.Resources.CPURealtimePeriod,
+		"cpurealtimeruntime": c.HostConfig.Resources.CPURealtimeRuntime,
 		"cpusetcpus":         c.HostConfig.Resources.CpusetCpus,
 		"cpusetmems":         c.HostConfig.Resources.CpusetMems,
-		"diskquota":          fmt.Sprintf("%d", c.HostConfig.Resources.DiskQuota),
-		"kernelmemory":       fmt.Sprintf("%d", c.HostConfig.Resources.KernelMemory),
-		"memoryreservation":  fmt.Sprintf("%d", c.HostConfig.Resources.MemoryReservation),
-		"memoryswap":         fmt.Sprintf("%d", c.HostConfig.Resources.MemorySwap),
-		"memoryswappiness":   fmt.Sprintf("%d", *c.HostConfig.Resources.MemorySwappiness),
+		"diskquota":          c.HostConfig.Resources.DiskQuota,
+		"kernelmemory":       c.HostConfig.Resources.KernelMemory,
+		"memoryreservation":  c.HostConfig.Resources.MemoryReservation,
+		"memoryswap":         c.HostConfig.Resources.MemorySwap,
+		"memoryswappiness":   *c.HostConfig.Resources.MemorySwappiness,
 		"oomkilldisable":     fmt.Sprintf("%t", *c.HostConfig.Resources.OomKillDisable),
-		"pidslimit":          fmt.Sprintf("%d", c.HostConfig.Resources.PidsLimit),
+		"pidslimit":          c.HostConfig.Resources.PidsLimit,
 	}
 
 	logging.Debug("[Container Info] Harvested [%+v]\n", result)
 
 	return result, nil
-}
-
-func ports(m nat.PortSet) []string {
-	keys := make([]string, len(m))
-
-	i := 0
-	for k := range m {
-		keys[i] = k.Port()
-		i++
-	}
-	return keys
 }
 
 func init() {

--- a/capabilities/container/init.go
+++ b/capabilities/container/init.go
@@ -1,0 +1,7 @@
+package container
+
+// Init exists to allow container init() functions to run when
+// invoked from the capabilities Init function, which is
+// itself invoked by the Lumogon command handler.
+func Init() {
+}

--- a/capabilities/docker/docker.go
+++ b/capabilities/docker/docker.go
@@ -14,7 +14,7 @@ var dockerDescription = `The 'docker' capability captures information related to
 
 var dockerCapability = dockeradapter.DockerAPICapability{
 	Capability: types.Capability{
-		Schema:      "http://puppet.com/lumogon/capability/label/draft-01/schema#1",
+		Schema:      "http://puppet.com/lumogon/capability/docker/draft-01/schema#1",
 		Title:       "Docker Server Information",
 		Name:        "docker",
 		Description: dockerDescription,

--- a/capabilities/init.go
+++ b/capabilities/init.go
@@ -1,6 +1,7 @@
 package capabilities
 
 import (
+	"github.com/puppetlabs/lumogon/capabilities/container"
 	"github.com/puppetlabs/lumogon/capabilities/diff"
 	"github.com/puppetlabs/lumogon/capabilities/docker"
 	"github.com/puppetlabs/lumogon/capabilities/host"
@@ -16,4 +17,5 @@ func Init() {
 	label.Init()
 	ospackages.Init()
 	diff.Init()
+	container.Init()
 }

--- a/capabilities/payloadfilter/filter.go
+++ b/capabilities/payloadfilter/filter.go
@@ -36,7 +36,8 @@ func filterMap(value map[string]interface{}) (map[string]interface{}, error) {
 			if coerced != "" {
 				result[key] = coerced
 			}
-
+		case int, int8, int16, int32, int64:
+			result[key] = coerced
 		case map[string]interface{}:
 			nested, err := filterMap(coerced)
 			if err != nil {

--- a/capabilities/payloadfilter/filter_test.go
+++ b/capabilities/payloadfilter/filter_test.go
@@ -38,15 +38,19 @@ var filterTests = []filterTest{
 		false,
 	},
 	{
-		"A map with simple non-string values should fail with an error",
+		"Native JSON ints should be passed through unchanged",
 		map[string]interface{}{
 			"a": 1,
 			"b": 2,
 			"c": "3",
 			"d": "4",
 		},
-		map[string]interface{}{},
-		true,
+		map[string]interface{}{
+			"a": 1,
+			"b": 2,
+			"c": "3",
+			"d": "4"},
+		false,
 	},
 	{
 		"A map with complex non-string values should fail with an error",


### PR DESCRIPTION
**NOTE** This PR builds on #57 which should be merged first

This PR adds a basic container info capability that harvests a subset of the data available to ContainerInspect, it does not currently expose any structured data (pending UI updates) or any data that may container sensitive data.

Have tested against both Docker 1.12.6 (API 1.24) and 17.06.2-ce (API 1.30).

Sample captured data:
```
"capabilities": {
"container": {
    "$schema": "http://puppet.com/lumogon/capability/container/draft-01/schema#1",
    "title": "Container Information",
    "type": "dockerapi",
    "harvestid": "d0c4cfd6-4b69-480b-a595-d46ed4bcc993",
    "payload": {
    "AttachStderr": "true",
    "AttachStdin": "true",
    "AttachStdout": "true",
    "CPUPeriod": "0",
    "CPUQuota": "0",
    "CPURealtimePeriod": "0",
    "CPURealtimeRuntime": "0",
    "CPUShares": "0",
    "CapDrop": "SETUID, SETGID, FOWNER",
    "DiskQuota": "0",
    "Hostname": "52ffb9031513",
    "Image": "fedora",
    "KernelMemory": "0",
    "Memory": "0",
    "MemoryReservation": "0",
    "MemorySwap": "0",
    "MemorySwappiness": "-1",
    "NanoCPUs": "0",
    "OomKillDisable": "false",
    "OpenStdin": "true",
    "PidsLimit": "0",
    "Privileged": "false",
    "PublishAllPorts": "false",
    "ReadonlyRootfs": "false",
    "Runtime": "runc",
    "ShmSize": "67108864",
    "StdinOnce": "true",
    "Tty": "true"
    }
},
```

And a sample report:
![screen shot 2017-09-20 at 15 23 59](https://user-images.githubusercontent.com/83862/30649296-d064a93c-9e17-11e7-9fc4-27fed10ad4e2.png)
