### PR TITLE
(DI-738) Check for null ptr before dereference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ matrix:
     services: docker
     bundler_args: --without development
     env: PUPPET_GEM_VERSION="~> 4.0"
-    install: cd contrib/puppetlabs-lumogon && make bootstrap
+    install:
+      - make image
+      - cd contrib/puppetlabs-lumogon && make bootstrap
     script: make vendor test
 deploy:
 - provider: script

--- a/capabilities/container/container.go
+++ b/capabilities/container/container.go
@@ -54,6 +54,16 @@ func InspectContainer(client dockeradapter.Harvester, targetID string) (map[stri
 	// support in the UI, it also avoids any config that could potentially contain
 	// sensitive data.
 
+	var memorySwappiness int64
+	if c.HostConfig.Resources.MemorySwappiness != nil {
+		memorySwappiness = *c.HostConfig.Resources.MemorySwappiness
+	}
+
+	var oomKillDisable bool
+	if c.HostConfig.Resources.OomKillDisable != nil {
+		oomKillDisable = *c.HostConfig.Resources.OomKillDisable
+	}
+
 	result := map[string]interface{}{
 		"hostname":           c.Config.Hostname,
 		"domainname":         c.Config.Domainname,
@@ -85,8 +95,8 @@ func InspectContainer(client dockeradapter.Harvester, targetID string) (map[stri
 		"kernelmemory":       c.HostConfig.Resources.KernelMemory,
 		"memoryreservation":  c.HostConfig.Resources.MemoryReservation,
 		"memoryswap":         c.HostConfig.Resources.MemorySwap,
-		"memoryswappiness":   *c.HostConfig.Resources.MemorySwappiness,
-		"oomkilldisable":     fmt.Sprintf("%t", *c.HostConfig.Resources.OomKillDisable),
+		"memoryswappiness":   memorySwappiness,
+		"oomkilldisable":     fmt.Sprintf("%t", oomKillDisable),
 		"pidslimit":          c.HostConfig.Resources.PidsLimit,
 	}
 

--- a/contrib/puppetlabs-lumogon/spec/integration/puppet_resource_spec.rb
+++ b/contrib/puppetlabs-lumogon/spec/integration/puppet_resource_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe "puppetlabs-lumogon integration" do
   before(:all) do
     `docker run -it --privileged --name dind-test -d docker:dind`
+    `docker save puppet/lumogon:latest > latestimg.tar`
+    `docker run -it --rm --link dind-test:docker docker load < latestimg.tar`
     `docker run -it --rm --link dind-test:docker docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"`
   end
 


### PR DESCRIPTION
This PR fixes a bug in the container capability where a null pointer was being dereferenced for the memorySwappiness hostconfig resource.

It checks for the null before attempting to dereference, also fixes this for the oomKillDisable param.

This would result in the following panic when running the scan or report commands:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7280cf]
goroutine 39 [running]:
github.com/puppetlabs/lumogon/capabilities/container.InspectContainer(0x7f8ee1155180, 0xc4202d9c40, 0xc4202d2fc0, 0x40, 0x2, 0x3535653700714648, 0x3134612d63653437)
	/go/src/github.com/puppetlabs/lumogon/capabilities/container/container.go:88 +0x1baf
github.com/puppetlabs/lumogon/capabilities/container.glob..func1(0xc420216000, 0x7f8ee1155180, 0xc4202d9c40, 0xc42036e0c0, 0x24, 0xc4202d2fc0, 0x40, 0xc4202dbd01, 0xf, 0x987414, ...)
	/go/src/github.com/puppetlabs/lumogon/capabilities/container/container.go:31 +0x160
 github.com/puppetlabs/lumogon/harvester.harvestDockerAPICapabilities(0xc4202d2fc0, 0x40, 0xc4202dbd01, 0xf, 0x987414, 0x7, 0x7f8ee1155180, 0xc4202d9c40, 0xc4201b7400, 0x7, ...)
	/go/src/github.com/puppetlabs/lumogon/harvester/dockerapi.go:54 +0x2e0
created by github.com/puppetlabs/lumogon/harvester.RunDockerAPIHarvester
	/go/src/github.com/puppetlabs/lumogon/harvester/dockerapi.go:31 +0x1da
```