### PR TITLE
(MAINT) Improve opensuse package support + bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 matrix:
   include:
-  - go: 1.8
+  - go: 1.9.1
     language: go
     install: make bootstrap
     script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3 as builder
+FROM golang:1.9.1 as builder
 RUN mkdir -p /go/src/github.com/puppetlabs/lumogon/
 COPY . /go/src/github.com/puppetlabs/lumogon/
 WORKDIR /go/src/github.com/puppetlabs/lumogon/

--- a/capabilities/ospackages/package.go
+++ b/capabilities/ospackages/package.go
@@ -22,7 +22,7 @@ func runPackageCmd(client dockeradapter.Harvester, containerID string, cmd []str
 	}
 	logging.Debug("[Package] Container Exec Created, ID: %s", execInstance.ID)
 
-	att, err := client.ContainerExecAttach(ctx, execInstance.ID, cmd, attachStdout, attachStderr)
+	att, err := client.ContainerExecAttach(ctx, execInstance.ID)
 	if err != nil {
 		err = fmt.Errorf("[Package] Unable to attach exec: %s", err)
 		logging.Debug(err.Error())

--- a/capabilities/ospackages/package_test.go
+++ b/capabilities/ospackages/package_test.go
@@ -48,7 +48,7 @@ var runPackageCmdTests = []struct {
 		title: "Error attaching to exec",
 		mockHarvesterDockerClient: &mocks.MockDockerClient{
 			ContainerExecCreateFn: successfulContainerExecCreateFn,
-			ContainerExecAttachFn: func(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error) {
+			ContainerExecAttachFn: func(ctx context.Context, execID string) (dockertypes.HijackedResponse, error) {
 				return dockertypes.HijackedResponse{}, fmt.Errorf("Dummy ContainerExecAttach error")
 			},
 		},

--- a/capabilities/ospackages/packagehelpers_test.go
+++ b/capabilities/ospackages/packagehelpers_test.go
@@ -15,8 +15,8 @@ func successfulContainerExecCreateFn(ctx context.Context, containerID string, cm
 	return mockIDResponse, nil
 }
 
-func createSuccesfulContainerExecAttachFn(buf []byte) func(context.Context, string, []string, bool, bool) (dockertypes.HijackedResponse, error) {
-	var succesfulContainerExecAttachFn = func(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error) {
+func createSuccesfulContainerExecAttachFn(buf []byte) func(context.Context, string) (dockertypes.HijackedResponse, error) {
+	var succesfulContainerExecAttachFn = func(ctx context.Context, execID string) (dockertypes.HijackedResponse, error) {
 		mockHijackedResponse := dockertypes.HijackedResponse{}
 		mockHijackedResponse.Conn = mocks.MockNetConn{
 			CloseFn: func() error {

--- a/dockeradapter/dockeradapter.go
+++ b/dockeradapter/dockeradapter.go
@@ -66,7 +66,7 @@ type Inspector interface {
 type Executor interface {
 	ContainerExecCreate(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.IDResponse, error)
 	ContainerExecStart(ctx context.Context, execID string) error
-	ContainerExecAttach(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string) (dockertypes.HijackedResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (dockertypes.ContainerExecInspect, error)
 }
 
@@ -273,13 +273,9 @@ func (c *concreteDockerClient) ContainerExecStart(ctx context.Context, execID st
 	return c.Client.ContainerExecStart(ctx, execID, execStartOpts)
 }
 
-func (c *concreteDockerClient) ContainerExecAttach(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error) {
-	execOpts := dockertypes.ExecConfig{
-		Cmd:          cmd,
-		AttachStdout: attachStdout,
-		AttachStderr: attachStderr,
-	}
-	return c.Client.ContainerExecAttach(ctx, execID, execOpts)
+func (c *concreteDockerClient) ContainerExecAttach(ctx context.Context, execID string) (dockertypes.HijackedResponse, error) {
+	execStartOpts := dockertypes.ExecStartCheck{}
+	return c.Client.ContainerExecAttach(ctx, execID, execStartOpts)
 }
 
 func (c *concreteDockerClient) ContainerExecInspect(ctx context.Context, execID string) (dockertypes.ContainerExecInspect, error) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,21 @@
 hash: 2d469e87a521fe1cbc39c49b000eac3390a10261822bbd27c54f07295443e6a9
-updated: 2017-05-08T12:26:59.302170631-05:00
+updated: 2017-10-19T09:10:49.383626524Z
 imports:
+- name: github.com/containerd/continuity
+  version: 1bed1ecb1dc42d8f4d2ac8c23e5cac64749e82c9
+  subpackages:
+  - pathdriver
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: 08b06dc023674763e7b36d404cf0c7664cee1f5e
+  version: 7484e51bf6af0d3b1a849644cdaced3cfcf13617
   subpackages:
   - digestset
   - reference
 - name: github.com/docker/docker
-  version: 705e031b984e7d976fa5a9fef61e4a76451d6e36
+  version: 239d61f04bf1c00273c1c89b531fe37993e08a9f
   subpackages:
   - api
   - api/types
@@ -25,38 +29,44 @@ imports:
   - api/types/registry
   - api/types/strslice
   - api/types/swarm
+  - api/types/swarm/runtime
   - api/types/time
   - api/types/versions
   - api/types/volume
   - client
+  - pkg/archive
+  - pkg/fileutils
+  - pkg/idtools
   - pkg/ioutils
   - pkg/longpath
+  - pkg/mount
   - pkg/namesgenerator
-  - pkg/random
+  - pkg/pools
   - pkg/system
-  - pkg/tlsconfig
 - name: github.com/docker/go-connections
-  version: a2afab9802043837035592f1c24827fb70766de9
+  version: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
   subpackages:
   - nat
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
-- name: github.com/docker/libtrust
-  version: aabc10ec26b754e797f9028f4589c5b7bd90dc20
 - name: github.com/fsnotify/fsnotify
-  version: 7d7316ed6e1ed2de075aab8dfc76de5d158d66e1
+  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
 - name: github.com/go-ole/go-ole
-  version: de8695c8edbf8236f30d6e1376e20b198a028d42
+  version: 2ecd927eaf828c4fc088fae349b28eed1480ff56
   subpackages:
   - oleutil
+- name: github.com/gogo/protobuf
+  version: 117892bf1866fbaa2318c03e50e40564c8845457
+  subpackages:
+  - proto
 - name: github.com/google/go-querystring
   version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
 - name: github.com/hashicorp/hcl
-  version: 630949a3c5fa3c613328e1b8256052cbc2327c9b
+  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -69,23 +79,31 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
-  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
+  version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
 - name: github.com/Microsoft/go-winio
-  version: fff283ad5116362ca252298cfc9b95828956d85d
+  version: 78439966b38d69bf38227fbf57ac8a6fee70f69a
 - name: github.com/mitchellh/mapstructure
-  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+  version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/opencontainers/go-digest
-  version: aa2ec055abd10d26d539eb630a92241b781ce4bc
-- name: github.com/pelletier/go-buffruneio
-  version: c37440a7cf42ac63b919c752ca73a85067e05992
+  version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
+- name: github.com/opencontainers/image-spec
+  version: 7c889fafd04a893f5c5f50b7ab9963d5d64e5242
+  subpackages:
+  - specs-go
+  - specs-go/v1
+- name: github.com/opencontainers/runc
+  version: c05f6368afaf7f720c10b1207a51e40fccf05295
+  subpackages:
+  - libcontainer/system
+  - libcontainer/user
 - name: github.com/pelletier/go-toml
-  version: 13d49d4606eb801b8f01ae542b4afc4c6ee3d84a
+  version: 2009e44b6f182e34d8ce081ac2767622937ea3d4
 - name: github.com/pkg/errors
-  version: bfd5150e4e41705ded2129ec33379de1cb90b513
+  version: f15c970de5b76fac0b59abb32d62c17cc7bed265
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/shirou/gopsutil
-  version: 23f4b7eb149c4b07835a23057d6d168d9301d373
+  version: 48fc5612898a1213aa5d6a0fb2d4f7b968e898fb
   subpackages:
   - cpu
   - host
@@ -95,42 +113,46 @@ imports:
   - process
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
-- name: github.com/Sirupsen/logrus
-  version: 1deb2db2a6fff8a35532079061b903c3a25eed52
+- name: github.com/sirupsen/logrus
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
-  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
+  version: e67d870304c4bca21331b02f414f970df13aa694
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: ce135a4ebeee6cfe9a26c93ee0d37825f26113c7
+  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/cobra
-  version: 16c014f1a19d865b765b420e74508f80eb831ada
+  version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
 - name: github.com/spf13/jwalterweatherman
-  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
+  version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 1f33b80956cde38911d1f23d764deb8d77a649ce
 - name: github.com/spf13/viper
-  version: 7538d73b4eb9511d85a9f1dfef202eeb8ac260f4
+  version: d9cca5ef33035202efb1586825bdbb15ff9ec3ba
 - name: github.com/StackExchange/wmi
-  version: 9f32b5905fd6ce7384093f9d048437e79f7b4d85
+  version: ea383cf3ba6ec950874b8486cd72356d007c768f
+- name: golang.org/x/crypto
+  version: ed5229da99e3a6df35c756cd64b6982d19505d86
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
-  version: a6577fac2d73be281a500b310739095313165611
+  version: 1087133bc4af3073e18add999345c6ae75918503
   subpackages:
   - context
   - context/ctxhttp
   - proxy
 - name: golang.org/x/sys
-  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  version: 8dbc5d05d6edcc104950cc299a1ce6641235bc86
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: f28f36722d5ef2f9655ad3de1f248e3e52ad5ebd
+  version: c01e4764d870b77f8abe5096ee19ad20d80e8075
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/h2non/gock.v1
-  version: 2897ffde93a71060ce86518f1e7317ec8433d2d6
+  version: 84d599244901620fb3eb96473eb9e50619f69b47
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -113,7 +113,7 @@ imports:
   - process
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
-- name: github.com/sirupsen/logrus
+- name: github.com/Sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
   version: e67d870304c4bca21331b02f414f970df13aa694

--- a/test/mocks/dockerclient.go
+++ b/test/mocks/dockerclient.go
@@ -27,7 +27,7 @@ type MockDockerClient struct {
 	ContainerListFn        func(ctx context.Context) ([]string, error)
 	ContainerExecCreateFn  func(ctx context.Context, containerID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.IDResponse, error)
 	ContainerExecStartFn   func(ctx context.Context, execID string) error
-	ContainerExecAttachFn  func(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error)
+	ContainerExecAttachFn  func(ctx context.Context, execID string) (dockertypes.HijackedResponse, error)
 	ContainerExecInspectFn func(ctx context.Context, execID string) (dockertypes.ContainerExecInspect, error)
 	ImageInspectFn         func(ctx context.Context, imageName string) (dockertypes.ImageInspect, error)
 	CopyFromContainerFn    func(ctx context.Context, container, srcPath string, followSymlink bool) (io.ReadCloser, dockertypes.ContainerPathStat, error)
@@ -157,15 +157,12 @@ func (c *MockDockerClient) ContainerExecStart(ctx context.Context, execID string
 }
 
 // ContainerExecAttach is a mock implementation of dockeradapter.ContainerExecAttach
-func (c *MockDockerClient) ContainerExecAttach(ctx context.Context, execID string, cmd []string, attachStdout bool, attachStderr bool) (dockertypes.HijackedResponse, error) {
+func (c *MockDockerClient) ContainerExecAttach(ctx context.Context, execID string) (dockertypes.HijackedResponse, error) {
 	if c.ContainerExecAttachFn != nil {
 		fmt.Println("[MockDockerClient] In ", utils.CurrentFunctionName())
 		fmt.Println("[MockDockerClient]  - ctx: ", ctx)
 		fmt.Println("[MockDockerClient]  - execID: ", execID)
-		fmt.Println("[MockDockerClient]  - cmd: ", cmd)
-		fmt.Println("[MockDockerClient]  - attachStdout: ", attachStdout)
-		fmt.Println("[MockDockerClient]  - attachStderr: ", attachStderr)
-		return c.ContainerExecAttachFn(ctx, execID, cmd, attachStdout, attachStderr)
+		return c.ContainerExecAttachFn(ctx, execID)
 	}
 	panic(fmt.Sprintf("No function defined for: %s", utils.CurrentFunctionName()))
 }


### PR DESCRIPTION
This PR improves support for opensuse in the rpm package capability and bumps all dependencies.

Prior to this commit the rpm capability was reliant on the presence of the `rpm` binary to list installed packages. This is not present on opensuse images, however the `rpmquery` command is present.

This commit adds a fallback to `rpmquery` when enumerating insalled packages.

*note* it also strips the `-(none)` returned from some packages which have the arch defined as none rather than an explicit `noarch`.

It also bumps dependencies and makes the associated update to the ContainerExecAttach signature, fixing the ContainerExecAttach to use `ExecStartCheck` rather than `ExecConfig` following the upstream fix in the Docker API.


